### PR TITLE
LambdaのデプロイをDockerイメージからzipへ移行

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+bootstrap
+node_modules
+package-lock.json
+.serverless
+.scala-build
+.bsp
+.metals
+.bloop
+target
+.idea
+.vscode
+env.yml

--- a/.github/workflows/serverless-dev.yml
+++ b/.github/workflows/serverless-dev.yml
@@ -24,6 +24,11 @@ jobs:
       - name: checkout
         uses: actions/checkout@v1
 
+      # zip版デプロイに必要な serverless-plugin-scripts を導入
+      # (パッケージング直前に Docker で bootstrap をビルドして取り出す)
+      - name: install plugins
+        run: npm install
+
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,6 @@ project/plugins/project/
 
 bootstrap
 
+node_modules/
+
 .idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,29 @@
-FROM virtuslab/scala-cli:latest as build-image
+# ビルド専用イメージ: Scala Native の `bootstrap` バイナリを Amazon Linux 2023 上で
+# コンパイルし、Lambda の `provided.al2023` ランタイムと glibc / libcurl を一致させる
+# (Debian 上でビルドしたバイナリは互換性のない libcurl/glibc にリンクされ、Lambda 上で
+#  GLIBC_* not found / curl OPERATION_TIMEDOUT でクラッシュする)。
+#
+# ここで作ったバイナリはコンテナイメージとしてではなく、抽出して Lambda の zip
+# (provided.al2023 カスタムランタイム) としてデプロイする。
+FROM --platform=linux/amd64 amazonlinux:2023 AS build-image
 
-RUN apt-get update && apt-get install -y libcurl4-openssl-dev && rm -rf /var/lib/apt/lists/*
+RUN dnf install -y \
+      clang \
+      gcc \
+      glibc-devel \
+      libstdc++-devel \
+      zlib-devel \
+      libcurl-devel \
+      openssl-devel \
+      libidn2-devel \
+      java-17-amazon-corretto-headless \
+      tar gzip which findutils \
+    && dnf clean all
+
+# scala-cli (static x86_64 linux launcher)
+RUN curl -fsSL https://github.com/VirtusLab/scala-cli/releases/latest/download/scala-cli-x86_64-pc-linux.gz \
+      | gunzip > /usr/local/bin/scala-cli \
+    && chmod +x /usr/local/bin/scala-cli
 
 WORKDIR /work
 COPY ./ ./
@@ -13,8 +36,30 @@ RUN scala-cli config power true
 RUN scala-cli --power package --native -o bootstrap .
 RUN chmod +x bootstrap
 
-FROM public.ecr.aws/lambda/provided:latest
-
-COPY --from=build-image /work/bootstrap /var/runtime/
-
-CMD ["dummyHandler"]
+# ============================================================================
+# 以下は Docker(コンテナイメージ)版の Lambda デプロイ用 Dockerfile。
+# zip(provided.al2023 カスタムランタイム)版へ移行したため無効化している。
+# サンプル実装として両方式を残すためコメントで保持。
+# ============================================================================
+#
+# FROM virtuslab/scala-cli:latest as build-image
+#
+# RUN apt-get update && apt-get install -y libcurl4-openssl-dev && rm -rf /var/lib/apt/lists/*
+#
+# WORKDIR /work
+# COPY ./ ./
+#
+# RUN scala-cli clean .
+# RUN scala-cli config power true
+# # target GraalVM
+# # RUN scala-cli --power package --native-image -o bootstrap .
+# # target Scala Native
+# RUN scala-cli --power package --native -o bootstrap .
+# RUN chmod +x bootstrap
+#
+# # コンテナイメージ版ではここで Lambda 用ベースイメージに bootstrap を載せていた
+# FROM public.ecr.aws/lambda/provided:latest
+#
+# COPY --from=build-image /work/bootstrap /var/runtime/
+#
+# CMD ["dummyHandler"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,33 @@
 Scala CLI（とScala Native）でAWS Lambdaを自力で動かして見たかった話
 Scalaらしいコードを書けたかというと微妙な気がするがまあいいでしょう
 
+  - scala3 / Scala Native / scala-cli
+  - aws lambda
+    - provided.al2023 カスタムランタイム (zipアップロード形式)
+  - serverless framework
+
+## デプロイ
+
+`bootstrap` (Scala Nativeバイナリ) をビルドして zip でアップロードする。
+ビルドは Lambda 実行環境 (provided.al2023) と glibc/libcurl の互換性を保つため、
+Amazon Linux 2023 のコンテナ内で行う ([Dockerfile](Dockerfile))。
+
+`serverless-plugin-scripts` により、`sls deploy` / `sls package` の
+パッケージング直前 (`before:package:createDeploymentArtifacts`) に
+`bootstrap` が自動でビルド・取り出しされる (Docker が必要)。
+
 ```shell
-# deploy
+# プラグインをインストール
+$ npm install
+
+# deploy (bootstrap の生成 → zip化 → アップロードまで自動)
 $ sls deploy --stage <stage_name>
 ```
+
+## Docker（コンテナイメージ）版について
+
+このリポジトリはサンプル実装のため、以前の Docker イメージ
+（ECR コンテナイメージ）版のデプロイ設定も各ファイルにコメントで残してある。
+
+  - [serverless.yml](serverless.yml): `ecr.images` / `image.command` などをコメント保持
+  - [Dockerfile](Dockerfile): コンテナイメージ用のビルドステージをコメント保持

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "lambda-scala-sls",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Scala CLI (Scala Native) で AWS Lambda を動かすサンプル (zip デプロイ)",
+  "devDependencies": {
+    "serverless-plugin-scripts": "^1.0.2"
+  }
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,37 +1,64 @@
 service: lambda-scala-sls
 
+plugins:
+  - serverless-plugin-scripts
+
 custom:
   defaultStage: dev
+  scripts:
+    hooks:
+      # パッケージング(zip化)直前に、Lambda互換のネイティブバイナリ bootstrap を
+      # Docker内でビルドして取り出す。
+      "before:package:createDeploymentArtifacts": |
+        docker build --platform linux/amd64 -t lambda-scala-sls-build .
+        id=$(docker create --platform linux/amd64 lambda-scala-sls-build)
+        docker cp "$id":/work/bootstrap ./bootstrap
+        docker rm "$id"
+        chmod +x bootstrap
 
 provider:
   name: aws
-  runtime: provided
+  runtime: provided.al2023
+  architecture: x86_64
   timeout: 20
   region: ap-northeast-1
-  ecr:
-    images:
-      appImage:
-        path: ./
-        platform: linux/amd64
   stage: ${opt:stage, self:custom.defaultStage}
+  # --- Docker(コンテナイメージ)版のデプロイ設定。zip版へ移行したため無効化 ---
+  # runtime: provided
+  # ecr:
+  #   images:
+  #     appImage:
+  #       path: ./
+  #       platform: linux/amd64
   # environment:
   #   ${file(./env.yml)}
 
+# zip には bootstrap のみ含める
+package:
+  patterns:
+    - "!**"
+    - bootstrap
+
 functions:
   hello:
-    image:
-      name: appImage
-      command:
-        - hello
+    # handler の値が環境変数 _HANDLER に渡り、Lambda.scala のディスパッチに使われる
+    handler: hello
+    # --- Docker版: コンテナイメージ + command でハンドラ指定 ---
+    # image:
+    #   name: appImage
+    #   command:
+    #     - hello
     events:
       - http:
           path: test
           method: get
   world:
-    image:
-      name: appImage
-      command:
-        - world
+    handler: world
+    # --- Docker版: コンテナイメージ + command でハンドラ指定 ---
+    # image:
+    #   name: appImage
+    #   command:
+    #     - world
     events:
       - http:
           path: test


### PR DESCRIPTION
## 概要

AWS Lambda のデプロイ方式を Docker（ECR コンテナイメージ）から zip（`provided.al2023` カスタムランタイム）へ移行しました。
本リポジトリはサンプル実装のため、Docker版の設定は各ファイルにコメントで残しています。

参考: https://github.com/limit7412/no_review_notifications_slack

## 変更点

- **serverless.yml**: `ecr.images` → `serverless-plugin-scripts` のフック (`before:package:createDeploymentArtifacts`) で `bootstrap` をビルドして zip化。`runtime: provided.al2023` / `architecture: x86_64` / `package.patterns` で `bootstrap` のみ含める。各 function は `handler: hello` / `handler: world`（旧 `image.command` はコメント保持）
- **Dockerfile**: コンテナイメージ用2ステージ → `bootstrap` ビルド専用（`amazonlinux:2023`。Lambda の glibc/libcurl との互換性確保のため）。旧コンテナイメージ版は末尾にコメント保持
- **package.json / .dockerignore**: 追加
- **.gitignore**: `node_modules/` 等を追加
- **.github/workflows/serverless-dev.yml**: プラグイン導入用 `npm install` ステップ追加
- **README.md**: zip版デプロイ手順に更新

## 動作確認

Docker版を `sls remove` → zip版を `sls deploy --stage dev` し、両エンドポイントで HTTP 200 を確認済み。

| Method | レスポンス |
|--------|-----------|
| `GET /test` (hello) | `{"msg":"さよなら透明だった僕たち"}` |
| `POST /test` (world) | `{"msg":"でしょうねミスター・サーバーレス","body":"..."}` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)