### PR TITLE
build: static (musl) build for Lambda bootstrap (#22)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,42 @@
-# ビルド専用イメージ: Scala Native の `bootstrap` バイナリを Amazon Linux 2023 上で
-# コンパイルし、Lambda の `provided.al2023` ランタイムと glibc / libcurl を一致させる
-# (Debian 上でビルドしたバイナリは互換性のない libcurl/glibc にリンクされ、Lambda 上で
-#  GLIBC_* not found / curl OPERATION_TIMEDOUT でクラッシュする)。
+# ビルド専用イメージ: Scala Native の `bootstrap` バイナリを Alpine (musl) 上で
+# 静的リンク(static)してビルドする (#22)。
+#
+# 完全静的リンクにより、Lambda 実行環境 (provided.al2023) の glibc / libcurl の
+# バージョンに依存しない自己完結バイナリになる。これによりビルド環境とランタイム
+# 環境のライブラリ整合を取る必要がなくなる (従来は Amazon Linux 2023 上でビルドして
+# glibc/libcurl を一致させていた。下部にコメントで保持)。
 #
 # ここで作ったバイナリはコンテナイメージとしてではなく、抽出して Lambda の zip
 # (provided.al2023 カスタムランタイム) としてデプロイする。
-FROM --platform=linux/arm64 amazonlinux:2023 AS build-image
+FROM --platform=linux/arm64 alpine:3.21 AS build-image
 
-RUN dnf install -y \
-      clang \
-      gcc \
-      glibc-devel \
-      libstdc++-devel \
-      zlib-devel \
-      libcurl-devel \
-      openssl-devel \
-      libidn2-devel \
-      java-17-amazon-corretto-headless \
-      tar gzip which findutils \
-    && dnf clean all
+# ビルドツールチェーン + libcurl とその推移的依存の「静的アーカイブ(.a)」一式。
+#  - Scala Native は clang でコンパイル/リンクするため clang/lld/llvm が必要
+#  - scala-cli の glibc 製ネイティブランチャを musl 上で動かすため gcompat を入れる
+#  - JVM は musl ネイティブの openjdk17 をシステム JVM として使う
+#  - *-static は libcurl(OpenSSL/zlib/nghttp2/brotli/zstd/idn2 ...) の静的リンク用
+RUN apk add --no-cache \
+      bash curl tar gzip which findutils coreutils \
+      build-base clang lld llvm \
+      gcompat libstdc++ libgcc \
+      openjdk17 \
+      pkgconf \
+      curl-static curl-dev \
+      openssl-libs-static \
+      zlib-static \
+      nghttp2-static \
+      brotli-static \
+      zstd-static \
+      libidn2-static \
+      libunistring-static \
+      libpsl-static \
+      c-ares-static
 
-# scala-cli (static arm64 linux launcher)
+# scala-cli にシステム JVM(musl ネイティブ)を使わせるため JAVA_HOME を明示
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+# scala-cli (arm64 linux launcher)。glibc 製のため gcompat 経由で実行する。
 RUN curl -fsSL https://github.com/VirtusLab/scala-cli/releases/latest/download/scala-cli-aarch64-pc-linux.gz \
       | gunzip > /usr/local/bin/scala-cli \
     && chmod +x /usr/local/bin/scala-cli
@@ -32,9 +48,46 @@ RUN scala-cli clean .
 RUN scala-cli config power true
 # target GraalVM
 # RUN scala-cli --power package --native-image -o bootstrap .
-# target Scala Native
-RUN scala-cli --power package --native -o bootstrap .
+# target Scala Native (静的リンクは project.scala の nativeLinkingOptions で指定)
+#  --jvm system : musl ネイティブの openjdk17 を使用 (glibc JVM の自動DLを回避)
+#  --server=false: Bloop ビルドサーバを使わずインプロセスでビルド
+RUN scala-cli --power package --native --jvm system --server=false -o bootstrap .
 RUN chmod +x bootstrap
+# 静的バイナリであることの簡易確認 (動的依存が無ければ "not a dynamic executable")
+RUN ldd bootstrap || true
+
+# ============================================================================
+# 旧: Amazon Linux 2023 (glibc) 上で動的リンクビルドしていた版。
+# Lambda 実行環境と glibc/libcurl を一致させるため AL2023 上でビルドしていたが、
+# 静的(musl)リンク版 (#22) へ移行したためコメントで保持。
+# ============================================================================
+#
+# FROM --platform=linux/arm64 amazonlinux:2023 AS build-image
+#
+# RUN dnf install -y \
+#       clang \
+#       gcc \
+#       glibc-devel \
+#       libstdc++-devel \
+#       zlib-devel \
+#       libcurl-devel \
+#       openssl-devel \
+#       libidn2-devel \
+#       java-17-amazon-corretto-headless \
+#       tar gzip which findutils \
+#     && dnf clean all
+#
+# RUN curl -fsSL https://github.com/VirtusLab/scala-cli/releases/latest/download/scala-cli-aarch64-pc-linux.gz \
+#       | gunzip > /usr/local/bin/scala-cli \
+#     && chmod +x /usr/local/bin/scala-cli
+#
+# WORKDIR /work
+# COPY ./ ./
+#
+# RUN scala-cli clean .
+# RUN scala-cli config power true
+# RUN scala-cli --power package --native -o bootstrap .
+# RUN chmod +x bootstrap
 
 # ============================================================================
 # 以下は Docker(コンテナイメージ)版の Lambda デプロイ用 Dockerfile。

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ FROM --platform=linux/arm64 alpine:3.21 AS build-image
 #  - scala-cli の glibc 製ネイティブランチャを musl 上で動かすため gcompat を入れる
 #  - JVM は musl ネイティブの openjdk17 をシステム JVM として使う
 #  - *-static は libcurl(OpenSSL/zlib/nghttp2/brotli/zstd/idn2 ...) の静的リンク用
+#  - c-ares-dev: Alpine の libcurl は c-ares 有効ビルドで libcurl.a が ares_* を
+#    参照する。Alpine に c-ares-static は無く libcares.a は c-ares-dev に含まれる
 RUN apk add --no-cache \
       bash curl tar gzip which findutils coreutils \
       build-base clang lld llvm \
@@ -29,7 +31,8 @@ RUN apk add --no-cache \
       zstd-static \
       libidn2-static \
       libunistring-static \
-      libpsl-static
+      libpsl-static \
+      c-ares-dev
 
 # scala-cli にシステム JVM(musl ネイティブ)を使わせるため JAVA_HOME を明示
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
@@ -51,25 +54,15 @@ RUN scala-cli config power true
 #  --jvm system : musl ネイティブの openjdk17 を使用 (glibc JVM の自動DLを回避)
 #  --server=false: Bloop ビルドサーバを使わずインプロセスでビルド
 #  --native-linking: 完全静的リンク。Scala Native は @link("curl") で -lcurl のみ
-#    付与するため libcurl の推移的依存(OpenSSL/zlib/nghttp2/brotli/zstd/idn2 等)を
-#    明示し、静的リンク時の解決順序問題を避けるため --start-group/--end-group で囲む。
+#    付与するため libcurl の推移的依存(c-ares/OpenSSL/zlib/nghttp2/brotli/zstd/idn2/
+#    psl 等)を明示する。これらは相互依存(例: libpsl→idn2, brotlidec→brotlicommon)
+#    があり、静的リンクでは解決順序が問題になる。--start-group/--end-group を別々の
+#    --native-linking で渡すと Scala Native のオプション整列でグループが分断され得る
+#    ため、グループ全体を 1 つの -Wl, 引数にまとめて原子的に渡す。
 #    (Linux/リンカー依存のため project.scala ではなくここで指定し移植性を保つ)
 RUN scala-cli --power package --native --jvm system --server=false \
       --native-linking "-static" \
-      --native-linking "-Wl,--start-group" \
-      --native-linking "-lcurl" \
-      --native-linking "-lnghttp2" \
-      --native-linking "-lssl" \
-      --native-linking "-lcrypto" \
-      --native-linking "-lz" \
-      --native-linking "-lbrotlienc" \
-      --native-linking "-lbrotlidec" \
-      --native-linking "-lbrotlicommon" \
-      --native-linking "-lzstd" \
-      --native-linking "-lidn2" \
-      --native-linking "-lunistring" \
-      --native-linking "-lpsl" \
-      --native-linking "-Wl,--end-group" \
+      --native-linking "-Wl,--start-group,-lcurl,-lnghttp2,-lssl,-lcrypto,-lz,-lbrotlienc,-lbrotlidec,-lbrotlicommon,-lzstd,-lidn2,-lunistring,-lpsl,-lcares,--end-group" \
       -o bootstrap .
 RUN chmod +x bootstrap
 # 静的バイナリであることをアサート: musl では静的バイナリに ldd すると非ゼロ終了

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,17 @@ RUN curl -fsSL https://github.com/VirtusLab/scala-cli/releases/latest/download/s
 
 # Alpine の libbrotlidec.a / libpsl.a は GCC LTO (GIMPLE bitcode) の静的アーカイブで、
 # GNU ld は LTO プラグイン無しでは中の object を読めず "plugin needed to handle lto
-# object" となり BrotliDecoder* / psl_* を解決できない。GCC の liblto_plugin.so を
-# binutils のプラグイン探索ディレクトリ(bfd-plugins)へ symlink し ld に自動ロードさせる。
-RUN mkdir -p /usr/lib/bfd-plugins \
-    && ln -sf "$(ls /usr/lib/gcc/*/*/liblto_plugin.so | head -n1)" /usr/lib/bfd-plugins/liblto_plugin.so
+# object" となり BrotliDecoder* / psl_* を解決できない。
+# Scala Native のリンクで実際に使われるのはクロスターゲット用 ld
+# (/usr/<triple>/bin/ld) で、これは /usr/<triple>/lib/bfd-plugins を探索する
+# (gcc が用意する /usr/lib/bfd-plugins は見ない)。そこへ GCC の liblto_plugin.so を
+# symlink し、ld が LTO object を自動で扱えるようにする。
+RUN PLUGIN="$(gcc -print-prog-name=liblto_plugin.so)" \
+    && test -e "$PLUGIN" \
+    && D="/usr/$(gcc -dumpmachine)/lib/bfd-plugins" \
+    && mkdir -p "$D" \
+    && ln -sf "$PLUGIN" "$D/liblto_plugin.so" \
+    && ls -l "$D/liblto_plugin.so"
 
 WORKDIR /work
 COPY ./ ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,11 @@ FROM --platform=linux/arm64 alpine:3.21 AS build-image
 #  - c-ares-dev: Alpine の libcurl は c-ares 有効ビルドで libcurl.a が ares_* を
 #    参照する。Alpine に c-ares-static は無く libcares.a は c-ares-dev に含まれる
 #  - brotli/libpsl は Alpine の *-static が GCC LTO アーカイブでクロス ld が解決
-#    できないため後段でソースから非LTO静的ビルドする。cmake と libidn2/unistring
-#    の dev ヘッダ(libpsl ビルド用)を入れる
+#    できないため後段でソースから非LTO静的ビルドする。cmake(brotli)、python3
+#    (libpsl の configure が必須)、libidn2/unistring の dev ヘッダ(libpsl 用)を入れる
 RUN apk add --no-cache \
       bash curl tar gzip which findutils coreutils \
-      build-base clang lld llvm cmake \
+      build-base clang lld llvm cmake python3 \
       gcompat libstdc++ libstdc++-dev libgcc \
       openjdk17 \
       pkgconf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ RUN apk add --no-cache \
       zstd-static \
       libidn2-static \
       libunistring-static \
-      libpsl-static \
-      c-ares-static
+      libpsl-static
 
 # scala-cli にシステム JVM(musl ネイティブ)を使わせるため JAVA_HOME を明示
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,13 @@ RUN curl -fsSL https://github.com/VirtusLab/scala-cli/releases/latest/download/s
       | gunzip > /usr/local/bin/scala-cli \
     && chmod +x /usr/local/bin/scala-cli
 
+# Alpine の libbrotlidec.a / libpsl.a は GCC LTO (GIMPLE bitcode) の静的アーカイブで、
+# GNU ld は LTO プラグイン無しでは中の object を読めず "plugin needed to handle lto
+# object" となり BrotliDecoder* / psl_* を解決できない。GCC の liblto_plugin.so を
+# binutils のプラグイン探索ディレクトリ(bfd-plugins)へ symlink し ld に自動ロードさせる。
+RUN mkdir -p /usr/lib/bfd-plugins \
+    && ln -sf "$(ls /usr/lib/gcc/*/*/liblto_plugin.so | head -n1)" /usr/lib/bfd-plugins/liblto_plugin.so
+
 WORKDIR /work
 COPY ./ ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM --platform=linux/arm64 alpine:3.21 AS build-image
 RUN apk add --no-cache \
       bash curl tar gzip which findutils coreutils \
       build-base clang lld llvm \
-      gcompat libstdc++ libgcc \
+      gcompat libstdc++ libstdc++-dev libgcc \
       openjdk17 \
       pkgconf \
       curl-static curl-dev \
@@ -47,13 +47,34 @@ RUN scala-cli clean .
 RUN scala-cli config power true
 # target GraalVM
 # RUN scala-cli --power package --native-image -o bootstrap .
-# target Scala Native (静的リンクは project.scala の nativeLinkingOptions で指定)
+# target Scala Native
 #  --jvm system : musl ネイティブの openjdk17 を使用 (glibc JVM の自動DLを回避)
 #  --server=false: Bloop ビルドサーバを使わずインプロセスでビルド
-RUN scala-cli --power package --native --jvm system --server=false -o bootstrap .
+#  --native-linking: 完全静的リンク。Scala Native は @link("curl") で -lcurl のみ
+#    付与するため libcurl の推移的依存(OpenSSL/zlib/nghttp2/brotli/zstd/idn2 等)を
+#    明示し、静的リンク時の解決順序問題を避けるため --start-group/--end-group で囲む。
+#    (Linux/リンカー依存のため project.scala ではなくここで指定し移植性を保つ)
+RUN scala-cli --power package --native --jvm system --server=false \
+      --native-linking "-static" \
+      --native-linking "-Wl,--start-group" \
+      --native-linking "-lcurl" \
+      --native-linking "-lnghttp2" \
+      --native-linking "-lssl" \
+      --native-linking "-lcrypto" \
+      --native-linking "-lz" \
+      --native-linking "-lbrotlienc" \
+      --native-linking "-lbrotlidec" \
+      --native-linking "-lbrotlicommon" \
+      --native-linking "-lzstd" \
+      --native-linking "-lidn2" \
+      --native-linking "-lunistring" \
+      --native-linking "-lpsl" \
+      --native-linking "-Wl,--end-group" \
+      -o bootstrap .
 RUN chmod +x bootstrap
-# 静的バイナリであることの簡易確認 (動的依存が無ければ "not a dynamic executable")
-RUN ldd bootstrap || true
+# 静的バイナリであることをアサート: musl では静的バイナリに ldd すると非ゼロ終了
+# するため、! で反転し「動的リンクだったらビルド失敗」させる。
+RUN ! ldd bootstrap
 
 # ============================================================================
 # 旧: Amazon Linux 2023 (glibc) 上で動的リンクビルドしていた版。

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN curl -fsSL "https://github.com/google/brotli/archive/refs/tags/v${BROTLI_VER
          -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_INSTALL_LIBDIR=lib \
     && cmake --build /tmp/brotli-build --target install -j "$(nproc)" \
     && for f in /usr/local/lib/libbrotli*-static.a; do \
-         [ -e "$f" ] && ln -sf "$f" "${f%-static.a}.a"; \
+         [ -e "$f" ] && ln -sf "$f" "${f%-static.a}.a" || true; \
        done \
     && ls -l /usr/local/lib/libbrotli*.a
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,15 @@ FROM --platform=linux/arm64 alpine:3.21 AS build-image
 #  - Scala Native は clang でコンパイル/リンクするため clang/lld/llvm が必要
 #  - scala-cli の glibc 製ネイティブランチャを musl 上で動かすため gcompat を入れる
 #  - JVM は musl ネイティブの openjdk17 をシステム JVM として使う
-#  - *-static は libcurl(OpenSSL/zlib/nghttp2/brotli/zstd/idn2 ...) の静的リンク用
+#  - *-static は libcurl(OpenSSL/zlib/nghttp2/zstd/idn2 ...) の静的リンク用
 #  - c-ares-dev: Alpine の libcurl は c-ares 有効ビルドで libcurl.a が ares_* を
 #    参照する。Alpine に c-ares-static は無く libcares.a は c-ares-dev に含まれる
+#  - brotli/libpsl は Alpine の *-static が GCC LTO アーカイブでクロス ld が解決
+#    できないため後段でソースから非LTO静的ビルドする。cmake と libidn2/unistring
+#    の dev ヘッダ(libpsl ビルド用)を入れる
 RUN apk add --no-cache \
       bash curl tar gzip which findutils coreutils \
-      build-base clang lld llvm \
+      build-base clang lld llvm cmake \
       gcompat libstdc++ libstdc++-dev libgcc \
       openjdk17 \
       pkgconf \
@@ -27,11 +30,9 @@ RUN apk add --no-cache \
       openssl-libs-static \
       zlib-static \
       nghttp2-static \
-      brotli-static \
       zstd-static \
-      libidn2-static \
-      libunistring-static \
-      libpsl-static \
+      libidn2-static libidn2-dev \
+      libunistring-static libunistring-dev \
       c-ares-dev
 
 # scala-cli にシステム JVM(musl ネイティブ)を使わせるため JAVA_HOME を明示
@@ -43,19 +44,37 @@ RUN curl -fsSL https://github.com/VirtusLab/scala-cli/releases/latest/download/s
       | gunzip > /usr/local/bin/scala-cli \
     && chmod +x /usr/local/bin/scala-cli
 
-# Alpine の libbrotlidec.a / libpsl.a は GCC LTO (GIMPLE bitcode) の静的アーカイブで、
-# GNU ld は LTO プラグイン無しでは中の object を読めず "plugin needed to handle lto
-# object" となり BrotliDecoder* / psl_* を解決できない。
-# Scala Native のリンクで実際に使われるのはクロスターゲット用 ld
-# (/usr/<triple>/bin/ld) で、これは /usr/<triple>/lib/bfd-plugins を探索する
-# (gcc が用意する /usr/lib/bfd-plugins は見ない)。そこへ GCC の liblto_plugin.so を
-# symlink し、ld が LTO object を自動で扱えるようにする。
-RUN PLUGIN="$(gcc -print-prog-name=liblto_plugin.so)" \
-    && test -e "$PLUGIN" \
-    && D="/usr/$(gcc -dumpmachine)/lib/bfd-plugins" \
-    && mkdir -p "$D" \
-    && ln -sf "$PLUGIN" "$D/liblto_plugin.so" \
-    && ls -l "$D/liblto_plugin.so"
+# Alpine の brotli-static / libpsl-static は GCC LTO (GIMPLE bitcode) の静的アーカイブで、
+# Scala Native のリンクで使われるクロス ld が中の object を解決できない
+# ("plugin needed to handle lto object" / undefined BrotliDecoder*・psl_*)。
+# そこで brotli と libpsl を非LTOの静的ライブラリとしてソースからビルドし /usr/local
+# へ入れ、リンク時に /usr/local/lib を優先させる。(他の依存=nghttp2/openssl/zlib/
+# zstd/idn2/unistring/c-ares は非LTO静的のためそのまま使える)
+
+# brotli (cmake, 非LTO 静的)。cmake が libbrotli*-static.a で出す版に備え、
+# サフィックス無しの別名(-lbrotlidec 等で参照可能に)も用意する。
+ARG BROTLI_VERSION=1.1.0
+RUN curl -fsSL "https://github.com/google/brotli/archive/refs/tags/v${BROTLI_VERSION}.tar.gz" \
+      | tar xz -C /tmp \
+    && cmake -S "/tmp/brotli-${BROTLI_VERSION}" -B /tmp/brotli-build \
+         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF \
+         -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_INSTALL_LIBDIR=lib \
+    && cmake --build /tmp/brotli-build --target install -j "$(nproc)" \
+    && for f in /usr/local/lib/libbrotli*-static.a; do \
+         [ -e "$f" ] && ln -sf "$f" "${f%-static.a}.a"; \
+       done \
+    && ls -l /usr/local/lib/libbrotli*.a
+
+# libpsl (autotools, 非LTO 静的)。--enable-builtin=no で PSL データ生成を省略
+# (curl の psl.c が要求するシンボルを満たすのが目的でランタイムでは未使用)。
+ARG LIBPSL_VERSION=0.21.5
+RUN curl -fsSL "https://github.com/rockdaboot/libpsl/releases/download/${LIBPSL_VERSION}/libpsl-${LIBPSL_VERSION}.tar.gz" \
+      | tar xz -C /tmp \
+    && cd "/tmp/libpsl-${LIBPSL_VERSION}" \
+    && ./configure --prefix=/usr/local --enable-static --disable-shared \
+         --enable-runtime=libidn2 --enable-builtin=no \
+    && make -j "$(nproc)" && make install \
+    && ls -l /usr/local/lib/libpsl.a
 
 WORKDIR /work
 COPY ./ ./
@@ -73,9 +92,11 @@ RUN scala-cli config power true
 #    があり、静的リンクでは解決順序が問題になる。--start-group/--end-group を別々の
 #    --native-linking で渡すと Scala Native のオプション整列でグループが分断され得る
 #    ため、グループ全体を 1 つの -Wl, 引数にまとめて原子的に渡す。
+#    -L/usr/local/lib でソースビルドした非LTOの brotli/libpsl を優先的に探索する。
 #    (Linux/リンカー依存のため project.scala ではなくここで指定し移植性を保つ)
 RUN scala-cli --power package --native --jvm system --server=false \
       --native-linking "-static" \
+      --native-linking "-L/usr/local/lib" \
       --native-linking "-Wl,--start-group,-lcurl,-lnghttp2,-lssl,-lcrypto,-lz,-lbrotlienc,-lbrotlidec,-lbrotlicommon,-lzstd,-lidn2,-lunistring,-lpsl,-lcares,--end-group" \
       -o bootstrap .
 RUN chmod +x bootstrap

--- a/README.md
+++ b/README.md
@@ -11,8 +11,12 @@ Scalaらしいコードを書けたかというと微妙な気がするがまあ
 ## デプロイ
 
 `bootstrap` (Scala Nativeバイナリ) をビルドして zip でアップロードする。
-ビルドは Lambda 実行環境 (provided.al2023) と glibc/libcurl の互換性を保つため、
-Amazon Linux 2023 のコンテナ内で行う ([Dockerfile](Dockerfile))。
+ビルドは Alpine (musl) コンテナ内で **静的リンク (static build)** して行う ([Dockerfile](Dockerfile))。
+完全静的リンクにより Lambda 実行環境 (provided.al2023) の glibc/libcurl の
+バージョンに依存しない自己完結バイナリになるため、ビルド環境とランタイム環境の
+ライブラリ整合を取る必要がなくなる (#22)。
+(以前は glibc/libcurl を一致させるため Amazon Linux 2023 上でビルドしていた。
+[Dockerfile](Dockerfile) 下部にコメントで保持)。
 
 `serverless-plugin-scripts` により、`sls deploy` / `sls package` の
 パッケージング直前 (`before:package:createDeploymentArtifacts`) に

--- a/project.scala
+++ b/project.scala
@@ -15,4 +15,4 @@
 // 推移的依存は明示的に並べる必要がある。静的リンク時の解決順序問題を避けるため
 // --start-group / --end-group で囲む。
 //> using nativeLinkingOptions "-static"
-//> using nativeLinkingOptions "-Wl,--start-group" "-lcurl" "-lnghttp2" "-lssl" "-lcrypto" "-lz" "-lbrotlienc" "-lbrotlidec" "-lbrotlicommon" "-lzstd" "-lidn2" "-lunistring" "-lpsl" "-lcares" "-Wl,--end-group"
+//> using nativeLinkingOptions "-Wl,--start-group" "-lcurl" "-lnghttp2" "-lssl" "-lcrypto" "-lz" "-lbrotlienc" "-lbrotlidec" "-lbrotlicommon" "-lzstd" "-lidn2" "-lunistring" "-lpsl" "-Wl,--end-group"

--- a/project.scala
+++ b/project.scala
@@ -5,3 +5,14 @@
 //> using platform native
 //> using toolkit default
 //> using dep "com.lihaoyi::upickle:4.4.2"
+
+// 静的(musl)リンク化 (#22)
+// Lambda ランタイム(provided.al2023)の glibc/libcurl のバージョンに依存しない
+// 自己完結バイナリを生成する。Alpine(musl) 上でビルドし、libcurl と推移的依存
+// (OpenSSL/zlib/nghttp2/brotli/zstd/idn2 等)を静的アーカイブから取り込む。
+//
+// Scala Native は @link("curl") により -lcurl のみを付与するため、libcurl の
+// 推移的依存は明示的に並べる必要がある。静的リンク時の解決順序問題を避けるため
+// --start-group / --end-group で囲む。
+//> using nativeLinkingOptions "-static"
+//> using nativeLinkingOptions "-Wl,--start-group" "-lcurl" "-lnghttp2" "-lssl" "-lcrypto" "-lz" "-lbrotlienc" "-lbrotlidec" "-lbrotlicommon" "-lzstd" "-lidn2" "-lunistring" "-lpsl" "-lcares" "-Wl,--end-group"

--- a/project.scala
+++ b/project.scala
@@ -6,13 +6,7 @@
 //> using toolkit default
 //> using dep "com.lihaoyi::upickle:4.4.2"
 
-// 静的(musl)リンク化 (#22)
-// Lambda ランタイム(provided.al2023)の glibc/libcurl のバージョンに依存しない
-// 自己完結バイナリを生成する。Alpine(musl) 上でビルドし、libcurl と推移的依存
-// (OpenSSL/zlib/nghttp2/brotli/zstd/idn2 等)を静的アーカイブから取り込む。
-//
-// Scala Native は @link("curl") により -lcurl のみを付与するため、libcurl の
-// 推移的依存は明示的に並べる必要がある。静的リンク時の解決順序問題を避けるため
-// --start-group / --end-group で囲む。
-//> using nativeLinkingOptions "-static"
-//> using nativeLinkingOptions "-Wl,--start-group" "-lcurl" "-lnghttp2" "-lssl" "-lcrypto" "-lz" "-lbrotlienc" "-lbrotlidec" "-lbrotlicommon" "-lzstd" "-lidn2" "-lunistring" "-lpsl" "-Wl,--end-group"
+// 静的(musl)リンクのオプションは project.scala には置かない (#22)。
+// -static や -Wl,--start-group 等は Linux/リンカー依存で、macOS/Windows での
+// ローカル開発(scala-cli run/test)を壊すため、Alpine ビルド時の scala-cli
+// コマンドに --native-linking フラグとして渡す (Dockerfile 参照)。


### PR DESCRIPTION
## 概要

#22「static build化」の **案A（musl + 完全静的リンク）** を実装。

`bootstrap`（Scala Native バイナリ）を **Alpine(musl) 上で完全静的リンク**してビルドするように変更した。完全静的リンクにより、Lambda 実行環境（`provided.al2023`）の glibc / libcurl のバージョンに依存しない自己完結バイナリになるため、**ビルド環境とランタイム環境のライブラリ整合を取る必要がなくなる**（従来は AL2023 上でビルドして glibc/libcurl を一致させていた）。

closes #22

## 変更内容

- **`project.scala`**: `nativeLinkingOptions` に `-static` と libcurl の推移的依存（`-lcurl -lnghttp2 -lssl -lcrypto -lz -lbrotli* -lzstd -lidn2 -lunistring -lpsl -lcares`）を追加。Scala Native は `@link("curl")` で `-lcurl` のみ付与するため推移的依存を明示し、静的リンク時の解決順序問題を避けるため `--start-group`/`--end-group` で囲んでいる。
- **`Dockerfile`**: ビルドベースを `amazonlinux:2023` → `alpine:3.21` に変更。
  - `*-static` 系パッケージ（`curl-static`, `openssl-libs-static`, `zlib-static`, `nghttp2-static`, `brotli-static`, `zstd-static`, `libidn2-static`, `libunistring-static`, `libpsl-static`, `c-ares-static`）で静的アーカイブを導入
  - scala-cli の arm64 ランチャ（glibc 製）は `gcompat` 経由で実行
  - JVM は musl ネイティブの `openjdk17` をシステム JVM として使用（`--jvm system`）、`--server=false` で Bloop を使わずビルド
  - 旧 AL2023 版・Docker イメージ版はサンプルとしてコメントで保持
- **`README.md`**: 静的ビルド方針を反映

## 検証状況 ⚠️

**本変更はローカルでビルド検証できていません。** 作業環境が x86_64 ホスト（arm64 エミュレーション無し）かつ Docker Hub からの pull がネットワークポリシーで遮断されているため、Alpine コンテナでの arm64 ビルドを実行できませんでした。

実際の検証は、本 PR の **CI（`pull_request` → `ubuntu-24.04-arm` 上で `sls deploy` 実行 → `docker build --platform linux/arm64`）** が検証ゲートになります。CI が実 arm64 環境で Alpine 静的ビルドを実行します。

特に CI 実行で確認・調整が必要になり得る箇所:

- scala-cli の glibc ランチャが `gcompat` 上で正常動作するか
- 静的リンク時の `-l` フラグの**過不足・順序**（Alpine の libcurl が依存する全ライブラリを網羅できているか）
- 生成バイナリが本当に静的か（Dockerfile 末尾の `ldd bootstrap` が "not a dynamic executable" になるか）
- Lambda 上での hello / world 両エンドポイントの疎通

CI が失敗した場合はログに応じてリンクフラグ・パッケージを追従修正します。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQWmeW9pjd8Ka98Do3AogP)_