### PR TITLE
refactor: イベントループの末尾再帰化と var→val (#25)

### DIFF
--- a/src/runtime/Lambda.scala
+++ b/src/runtime/Lambda.scala
@@ -2,6 +2,7 @@ package serverless
 
 import sttp.client4.quick._
 import upickle.default._
+import scala.annotation.tailrec
 
 object Lambda {
   case class APIGatewayRequest(
@@ -24,8 +25,12 @@ object Lambda {
 
     this
   }
-  private def handler[A: Reader](callback: A => Response): Lambda.type = {
-    var response = quickRequest
+  // Lambda カスタムランタイムのイベントループ。
+  // /next で次の呼び出しを取得 → callback 実行 → /response か /error を通知、を繰り返す。
+  // 末尾再帰(@tailrec)とし、長時間稼働(ウォーム)でもスタックが伸びないことを保証する。
+  @tailrec
+  private def handler[A: Reader](callback: A => Response): Nothing = {
+    val response = quickRequest
       .get(
         uri"http://${sys.env("AWS_LAMBDA_RUNTIME_API")}/2018-06-01/runtime/invocation/next"
       )
@@ -62,6 +67,5 @@ object Lambda {
     }
 
     handler[A](callback)
-    this
   }
 }


### PR DESCRIPTION
## 概要

Closes #25

[no_review_notifications_slack のリファクタリング (limit7412/no_review_notifications_slack#15)](https://github.com/limit7412/no_review_notifications_slack/issues/15) の内容を、本テンプレートリポジトリに追従。

本リポジトリは `src/runtime/Lambda.scala` と `src/main.scala` のみのテンプレートのため、参照元のリファクタ済み `src/runtime/Lambda.scala` と照合し、該当する2点のみを適用しています。

## 変更内容

- **フェーズ1 (var→val)**: 再代入されていない `var response` を `val` に変更
- **フェーズ5 (末尾再帰化)**: Lambda カスタムランタイムのイベントループに `@tailrec` を付与しスタック安全性を明示。
  - 戻り値型を `Lambda.type` → `Nothing`（イベントループは正常終了しない無限ループのため）
  - 末尾の `this` を除去し、自己再帰呼び出しを末尾位置に配置（`@tailrec` の成立条件）
  - 意図を示すコメントを追記

## 対象外とした項目

参照元のリファクタリングのうち以下は、対象コード（`github` / `holiday` / `notify` / `config` 等）が本リポジトリに存在しないため対象外:

- フェーズ2: `null` → `Option`（`github/Models.scala` 不在）
- フェーズ3: DRY / Config 集約（アプリ設定の `sys.env` は無し。本リポジトリの `sys.env` は AWS ランタイム提供変数 `_HANDLER` / `AWS_LAMBDA_RUNTIME_API` のみ）
- フェーズ4: エラーハンドリング統一（対象 Repository 不在）
- フェーズ6: 色コード enum 化（対象不在）

## 確認

- `scala-cli compile .` 成功（`@tailrec` はコンパイラが末尾位置を検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)