### PR TITLE
build: libcurl を最小構成でソースビルドし Dockerfile を縮小 (#28)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,141 +1,73 @@
-# ビルド専用イメージ: Scala Native の `bootstrap` バイナリを Alpine (musl) 上で
-# 静的リンク(static)してビルドする (#22)。
-#
-# 完全静的リンクにより、Lambda 実行環境 (provided.al2023) の glibc / libcurl の
-# バージョンに依存しない自己完結バイナリになる。これによりビルド環境とランタイム
-# 環境のライブラリ整合を取る必要がなくなる (従来は Amazon Linux 2023 上でビルドして
-# glibc/libcurl を一致させていた。下部にコメントで保持)。
-#
-# ここで作ったバイナリはコンテナイメージとしてではなく、抽出して Lambda の zip
+# ビルド専用イメージ: Scala Native の `bootstrap` を Alpine (musl) 上で完全静的リンクする。
+# 生成物はコンテナイメージではなく、抽出して Lambda の zip
 # (provided.al2023 カスタムランタイム) としてデプロイする。
 FROM --platform=linux/arm64 alpine:3.21 AS build-image
 
-# ビルドツールチェーン + libcurl とその推移的依存の「静的アーカイブ(.a)」一式。
-#  - Scala Native は clang でコンパイル/リンクするため clang/lld/llvm が必要
-#  - scala-cli の glibc 製ネイティブランチャを musl 上で動かすため gcompat を入れる
-#  - JVM は musl ネイティブの openjdk17 をシステム JVM として使う
-#  - *-static は libcurl(OpenSSL/zlib/nghttp2/zstd/idn2 ...) の静的リンク用
-#  - c-ares-dev: Alpine の libcurl は c-ares 有効ビルドで libcurl.a が ares_* を
-#    参照する。Alpine に c-ares-static は無く libcares.a は c-ares-dev に含まれる
-#  - brotli/libpsl は Alpine の *-static が GCC LTO アーカイブでクロス ld が解決
-#    できないため後段でソースから非LTO静的ビルドする。cmake(brotli)、python3
-#    (libpsl の configure が必須)、libidn2/unistring の dev ヘッダ(libpsl 用)を入れる
+# clang/lld/llvm: Scala Native のコンパイル/リンク
+# gcompat: scala-cli の glibc 製ランチャを musl 上で動かす
+# openjdk17: システム JVM (musl ネイティブ)
+# libidn2/libunistring: libcurl ではなく sttp-model が @link("idn2") で要求する
 RUN apk add --no-cache \
-      bash curl tar gzip which findutils coreutils \
-      build-base clang lld llvm cmake python3 \
+      curl \
+      build-base clang lld llvm \
       gcompat libstdc++ libstdc++-dev libgcc \
       openjdk17 \
-      pkgconf \
-      curl-static curl-dev \
-      openssl-libs-static \
-      zlib-static \
-      nghttp2-static \
-      zstd-static \
       libidn2-static libidn2-dev \
-      libunistring-static libunistring-dev \
-      c-ares-dev
+      libunistring-static libunistring-dev
 
-# scala-cli にシステム JVM(musl ネイティブ)を使わせるため JAVA_HOME を明示
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
-# scala-cli (arm64 linux launcher)。glibc 製のため gcompat 経由で実行する。
 RUN curl -fsSL https://github.com/VirtusLab/scala-cli/releases/latest/download/scala-cli-aarch64-pc-linux.gz \
       | gunzip > /usr/local/bin/scala-cli \
     && chmod +x /usr/local/bin/scala-cli
 
-# Alpine の brotli-static / libpsl-static は GCC LTO (GIMPLE bitcode) の静的アーカイブで、
-# Scala Native のリンクで使われるクロス ld が中の object を解決できない
-# ("plugin needed to handle lto object" / undefined BrotliDecoder*・psl_*)。
-# そこで brotli と libpsl を非LTOの静的ライブラリとしてソースからビルドし /usr/local
-# へ入れ、リンク時に /usr/local/lib を優先させる。(他の依存=nghttp2/openssl/zlib/
-# zstd/idn2/unistring/c-ares は非LTO静的のためそのまま使える)
-
-# brotli (cmake, 非LTO 静的)。cmake が libbrotli*-static.a で出す版に備え、
-# サフィックス無しの別名(-lbrotlidec 等で参照可能に)も用意する。
-ARG BROTLI_VERSION=1.1.0
-RUN curl -fsSL "https://github.com/google/brotli/archive/refs/tags/v${BROTLI_VERSION}.tar.gz" \
-      | tar xz -C /tmp \
-    && cmake -S "/tmp/brotli-${BROTLI_VERSION}" -B /tmp/brotli-build \
-         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF \
-         -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_INSTALL_LIBDIR=lib \
-    && cmake --build /tmp/brotli-build --target install -j "$(nproc)" \
-    && for f in /usr/local/lib/libbrotli*-static.a; do \
-         [ -e "$f" ] && ln -sf "$f" "${f%-static.a}.a" || true; \
-       done \
-    && ls -l /usr/local/lib/libbrotli*.a
-
-# libpsl (autotools, 非LTO 静的)。--enable-builtin=no で PSL データ生成を省略
-# (curl の psl.c が要求するシンボルを満たすのが目的でランタイムでは未使用)。
-ARG LIBPSL_VERSION=0.21.5
-RUN curl -fsSL "https://github.com/rockdaboot/libpsl/releases/download/${LIBPSL_VERSION}/libpsl-${LIBPSL_VERSION}.tar.gz" \
-      | tar xz -C /tmp \
-    && cd "/tmp/libpsl-${LIBPSL_VERSION}" \
+# 最小構成の libcurl を静的ビルドする (#28)。
+# Alpine の curl-static は OpenSSL/nghttp2/brotli/zstd/psl/c-ares 込みのため、静的リンク
+# するとそれら全ての静的アーカイブが要る (うち brotli/libpsl は Alpine の *-static が
+# GCC LTO アーカイブでクロス ld が解決できず、ソースからの非LTOビルドが必要だった)。
+# 通信相手は Lambda Runtime API だけで TLS も名前解決も HTTP/2 も圧縮も不要なので、
+# それらを無効にして自前ビルドすれば依存ごと消える。
+ARG CURL_VERSION=8.11.1
+RUN curl -fsSL "https://curl.se/download/curl-${CURL_VERSION}.tar.gz" | tar xz -C /tmp \
+    && cd "/tmp/curl-${CURL_VERSION}" \
     && ./configure --prefix=/usr/local --enable-static --disable-shared \
-         --enable-runtime=libidn2 --enable-builtin=no \
-    && make -j "$(nproc)" && make install \
-    && ls -l /usr/local/lib/libpsl.a
+         --disable-ftp --disable-file --disable-ldap --disable-ldaps \
+         --disable-rtsp --disable-dict --disable-telnet --disable-tftp \
+         --disable-pop3 --disable-imap --disable-smb --disable-smtp \
+         --disable-gopher --disable-mqtt --disable-manual --disable-docs \
+         --without-ssl --without-zlib --without-brotli --without-zstd \
+         --without-libpsl --without-libidn2 --without-nghttp2 --without-ngtcp2 \
+         --without-libssh2 --without-librtmp --disable-ares \
+    && make -j "$(nproc)" && make install
 
 WORKDIR /work
 COPY ./ ./
 
 RUN scala-cli clean .
 RUN scala-cli config power true
-# target GraalVM
-# RUN scala-cli --power package --native-image -o bootstrap .
-# target Scala Native
-#  --jvm system : musl ネイティブの openjdk17 を使用 (glibc JVM の自動DLを回避)
-#  --server=false: Bloop ビルドサーバを使わずインプロセスでビルド
-#  --native-linking: 完全静的リンク。Scala Native は @link("curl") で -lcurl のみ
-#    付与するため libcurl の推移的依存(c-ares/OpenSSL/zlib/nghttp2/brotli/zstd/idn2/
-#    psl 等)を明示する。これらは相互依存(例: libpsl→idn2, brotlidec→brotlicommon)
-#    があり、静的リンクでは解決順序が問題になる。--start-group/--end-group を別々の
-#    --native-linking で渡すと Scala Native のオプション整列でグループが分断され得る
-#    ため、グループ全体を 1 つの -Wl, 引数にまとめて原子的に渡す。
-#    -L/usr/local/lib でソースビルドした非LTOの brotli/libpsl を優先的に探索する。
-#    (Linux/リンカー依存のため project.scala ではなくここで指定し移植性を保つ)
+#  --jvm system   : musl ネイティブの openjdk17 を使う (glibc JVM の自動DLを回避)
+#  --server=false : Bloop ビルドサーバを使わずインプロセスでビルド
+#  --native-linking: リンクオプションは Linux/リンカー依存のため project.scala ではなく
+#    ここで指定し、macOS/Windows でのローカル開発を壊さないようにする。
+#    Scala Native は @link 由来の -l を独自順で並べるため、解決順序に依存しないよう
+#    ライブラリ群は 1 つの -Wl, 引数にまとめて原子的に渡す。
 RUN scala-cli --power package --native --jvm system --server=false \
       --native-linking "-static" \
       --native-linking "-L/usr/local/lib" \
-      --native-linking "-Wl,--start-group,-lcurl,-lnghttp2,-lssl,-lcrypto,-lz,-lbrotlienc,-lbrotlidec,-lbrotlicommon,-lzstd,-lidn2,-lunistring,-lpsl,-lcares,--end-group" \
+      --native-linking "-Wl,--start-group,-lcurl,-lidn2,-lunistring,--end-group" \
       -o bootstrap .
 RUN chmod +x bootstrap
-# 静的バイナリであることをアサート: musl では静的バイナリに ldd すると非ゼロ終了
-# するため、! で反転し「動的リンクだったらビルド失敗」させる。
+# 静的リンクの検証。musl では静的バイナリへの ldd が非ゼロ終了するので ! で反転する。
 RUN ! ldd bootstrap
+# 起動できることの検証。_HANDLER 未設定なので NoSuchElementException で即終了するのが正常。
+# リンクが通り ldd 上も静的なのに起動しない構成 (下記 glibc + -static) を検知するため。
+RUN ./bootstrap 2>&1 | grep -q "NoSuchElementException: _HANDLER"
 
-# ============================================================================
-# 旧: Amazon Linux 2023 (glibc) 上で動的リンクビルドしていた版。
-# Lambda 実行環境と glibc/libcurl を一致させるため AL2023 上でビルドしていたが、
-# 静的(musl)リンク版 (#22) へ移行したためコメントで保持。
-# ============================================================================
-#
-# FROM --platform=linux/arm64 amazonlinux:2023 AS build-image
-#
-# RUN dnf install -y \
-#       clang \
-#       gcc \
-#       glibc-devel \
-#       libstdc++-devel \
-#       zlib-devel \
-#       libcurl-devel \
-#       openssl-devel \
-#       libidn2-devel \
-#       java-17-amazon-corretto-headless \
-#       tar gzip which findutils \
-#     && dnf clean all
-#
-# RUN curl -fsSL https://github.com/VirtusLab/scala-cli/releases/latest/download/scala-cli-aarch64-pc-linux.gz \
-#       | gunzip > /usr/local/bin/scala-cli \
-#     && chmod +x /usr/local/bin/scala-cli
-#
-# WORKDIR /work
-# COPY ./ ./
-#
-# RUN scala-cli clean .
-# RUN scala-cli config power true
-# RUN scala-cli --power package --native -o bootstrap .
-# RUN chmod +x bootstrap
+# #28 の本命だった「libcurl 排除 + 公式イメージ virtuslab/scala-cli (glibc) で x86_64」は
+# 不採用。HTTP を自前実装することになり趣旨から外れる上、glibc + -static の Scala Native
+# バイナリはリンクは通るが起動直後に SIGSEGV する (println("hello") だけでも再現。
+# 動的リンクなら正常、musl なら静的でも正常)。よって musl + arm64 を維持している。
 
 # ============================================================================
 # 以下は Docker(コンテナイメージ)版の Lambda デプロイ用 Dockerfile。
@@ -152,9 +84,6 @@ RUN ! ldd bootstrap
 #
 # RUN scala-cli clean .
 # RUN scala-cli config power true
-# # target GraalVM
-# # RUN scala-cli --power package --native-image -o bootstrap .
-# # target Scala Native
 # RUN scala-cli --power package --native -o bootstrap .
 # RUN chmod +x bootstrap
 #

--- a/README.md
+++ b/README.md
@@ -15,12 +15,44 @@ Scalaらしいコードを書けたかというと微妙な気がするがまあ
 完全静的リンクにより Lambda 実行環境 (provided.al2023) の glibc/libcurl の
 バージョンに依存しない自己完結バイナリになるため、ビルド環境とランタイム環境の
 ライブラリ整合を取る必要がなくなる (#22)。
-(以前は glibc/libcurl を一致させるため Amazon Linux 2023 上でビルドしていた。
-[Dockerfile](Dockerfile) 下部にコメントで保持)。
+(以前は glibc/libcurl を一致させるため Amazon Linux 2023 上でビルドしていた)。
 
 `serverless-plugin-scripts` により、`sls deploy` / `sls package` の
 パッケージング直前 (`before:package:createDeploymentArtifacts`) に
 `bootstrap` が自動でビルド・取り出しされる (Docker が必要)。
+
+### libcurl を最小構成でソースビルドしている理由 (#28)
+
+静的リンクの都合で、[Dockerfile](Dockerfile) では libcurl を自前でソースビルドしている。
+
+Alpine の `curl-static` は OpenSSL / nghttp2 / brotli / zstd / idn2 / psl / c-ares
+込みでビルドされているため、静的リンクするとそれら全ての静的アーカイブが芋づる式に
+必要になる。さらに Alpine の `brotli-static` / `libpsl-static` は GCC LTO 済みの
+アーカイブでクロス ld が中の object を解決できず、この 2 つはソースから非LTOで
+ビルドし直す必要があった (#22)。これが Dockerfile 肥大化の主因だった。
+
+通信相手は Lambda Runtime API (`http://127.0.0.1:9001/...`) だけで **TLS も名前解決も
+HTTP/2 も圧縮も不要**なので、それらを全て無効にした最小構成の libcurl をビルドすれば
+依存が消える。結果、`*-static` パッケージ群と brotli / libpsl のソースビルドが
+まるごと不要になり、リンク対象は libcurl と libidn2 → libunistring だけになった。
+
+なお libidn2 は libcurl ではなく **sttp-model が `@link("idn2")` で要求する**
+(国際化ドメイン名の変換用) ため、curl を最小化しても残る。
+
+### x86_64 + 公式イメージ案 (#28 の b-2) を見送った理由
+
+#28 の本命は「libcurl 依存そのものを排除 (HTTP を自前実装) すれば依存が libc だけに
+なり、amd64 単一アーキの公式イメージ `virtuslab/scala-cli` (Debian/glibc) 上でも
+`-static` が通る」という案だったが、次の 2 点により採用していない。
+
+1. HTTP クライアントを自前実装することになり、本リポジトリの趣旨から外れる。
+2. そもそも **glibc の完全静的リンクが成立しない**。glibc + `-static` の Scala Native
+   バイナリはリンクは通るが起動直後に SIGSEGV (exit 139) で落ちる。
+   `println("hello")` だけの最小プログラムでも再現するため本リポジトリのコードとは
+   無関係で、Scala Native ランタイムと glibc 静的リンクの相性問題。
+   動的リンクなら正常に起動し、musl なら静的でも正常に動作する。
+
+このため musl (Alpine) + arm64 (Graviton) を維持している。
 
 ```shell
 # プラグインをインストール

--- a/README.md
+++ b/README.md
@@ -21,39 +21,6 @@ Scalaらしいコードを書けたかというと微妙な気がするがまあ
 パッケージング直前 (`before:package:createDeploymentArtifacts`) に
 `bootstrap` が自動でビルド・取り出しされる (Docker が必要)。
 
-### libcurl を最小構成でソースビルドしている理由 (#28)
-
-静的リンクの都合で、[Dockerfile](Dockerfile) では libcurl を自前でソースビルドしている。
-
-Alpine の `curl-static` は OpenSSL / nghttp2 / brotli / zstd / idn2 / psl / c-ares
-込みでビルドされているため、静的リンクするとそれら全ての静的アーカイブが芋づる式に
-必要になる。さらに Alpine の `brotli-static` / `libpsl-static` は GCC LTO 済みの
-アーカイブでクロス ld が中の object を解決できず、この 2 つはソースから非LTOで
-ビルドし直す必要があった (#22)。これが Dockerfile 肥大化の主因だった。
-
-通信相手は Lambda Runtime API (`http://127.0.0.1:9001/...`) だけで **TLS も名前解決も
-HTTP/2 も圧縮も不要**なので、それらを全て無効にした最小構成の libcurl をビルドすれば
-依存が消える。結果、`*-static` パッケージ群と brotli / libpsl のソースビルドが
-まるごと不要になり、リンク対象は libcurl と libidn2 → libunistring だけになった。
-
-なお libidn2 は libcurl ではなく **sttp-model が `@link("idn2")` で要求する**
-(国際化ドメイン名の変換用) ため、curl を最小化しても残る。
-
-### x86_64 + 公式イメージ案 (#28 の b-2) を見送った理由
-
-#28 の本命は「libcurl 依存そのものを排除 (HTTP を自前実装) すれば依存が libc だけに
-なり、amd64 単一アーキの公式イメージ `virtuslab/scala-cli` (Debian/glibc) 上でも
-`-static` が通る」という案だったが、次の 2 点により採用していない。
-
-1. HTTP クライアントを自前実装することになり、本リポジトリの趣旨から外れる。
-2. そもそも **glibc の完全静的リンクが成立しない**。glibc + `-static` の Scala Native
-   バイナリはリンクは通るが起動直後に SIGSEGV (exit 139) で落ちる。
-   `println("hello")` だけの最小プログラムでも再現するため本リポジトリのコードとは
-   無関係で、Scala Native ランタイムと glibc 静的リンクの相性問題。
-   動的リンクなら正常に起動し、musl なら静的でも正常に動作する。
-
-このため musl (Alpine) + arm64 (Graviton) を維持している。
-
 ```shell
 # プラグインをインストール
 $ npm install


### PR DESCRIPTION
Refs #28 / #27 案5

## 方針

**Scala 側は一切変更していません。** Dockerfile 肥大化の主因だった
「静的 libcurl の推移的依存」を、**最小構成の libcurl をソースビルド**することで解消しました。
これは #27 で「案4 の前段としての妥協案」として挙げられていた **案5**（実現可否は要実測、とされていたもの）です。

> 当初 #28 本命の (b-2)（HTTP クライアント自前実装 + x86_64 + 公式イメージ）で実装しましたが、
> 「HTTP クライアントの自前実装では issue の目的が変わってしまう」とのご指摘を受けて案5 に切り替えました。

## なにが減ったか

Alpine の `curl-static` は OpenSSL / nghttp2 / brotli / zstd / idn2 / psl / c-ares 込みでビルドされているため、
静的リンクするとそれら全ての静的アーカイブが芋づる式に必要になります。
さらに Alpine の `brotli-static` / `libpsl-static` は **GCC LTO 済みアーカイブ**でクロス ld が中の object を
解決できず、この 2 つはソースから非LTOでビルドし直す必要がありました (#22)。

通信相手は Lambda Runtime API (`http://127.0.0.1:9001/...`) だけで **TLS も名前解決も HTTP/2 も圧縮も不要**なので、
それらを全て無効にした libcurl をビルドすれば依存が消えます。結果、以下がまるごと不要になりました。

- `*-static` パッケージ群 (curl / openssl / zlib / nghttp2 / zstd / c-ares) の `apk add`
- **brotli のソースビルド (11 行)**
- **libpsl のソースビルド (8 行)**
- `cmake` / `python3` / `pkgconf`（上記のためだけに入れていた）
- 14 ライブラリに及ぶリンクグループ → `-lcurl -lidn2 -lunistring` の 3 つに

| | 有効行 | 全行 |
|---|---:|---:|
| master | 50 | 166 |
| 本PR | **38** | 173 |

行数以上に、**LTO アーカイブ回避という一番説明の要る仕掛けが消えた**ことが大きいです
（#27 が指摘していた「コメント 47 行の大半が静的リンクの細工の説明」という状態が解消）。

### libidn2 は残ります

`-lidn2` は **libcurl ではなく sttp-model が `@link("idn2")` で要求**しています
(`sttp/model/internal/idn/CIdn.scala`、国際化ドメイン名の変換用)。
そのため curl を最小化しても残り、依存の libunistring と併せて 2 つだけ apk から静的リンクします。
どちらも非LTOアーカイブなのでソースビルドは不要です。

## ⚠️ x86_64 + 公式イメージ案 (#28 の b-2) は見送りました

#28 の本命だった案は、上記の趣旨の問題に加えて **技術的にも成立しません**でした。

| ビルド | 結果 |
|---|---|
| glibc (Debian) + `-static` | リンクは通るが**起動直後に SIGSEGV (exit 139)** |
| glibc (Debian) 動的リンク | 正常に起動 |
| musl (Alpine) + `-static` | 正常に起動 ✅ |

`println("hello")` だけの最小 Scala Native プログラムでも同じく SIGSEGV するため、
本リポジトリのコードや libcurl とは無関係で、**Scala Native ランタイムと glibc 静的リンクの相性問題**です。
ld も以下を警告しており整合します。

```
Using 'dlopen' in statically linked applications requires at runtime
the shared libraries from the glibc version used for linking
  (nativeThreadTLS.c の get_pthread_getattr_np, pwd.c の getpwnam/getpwuid)
```

当初 amd64 + QEMU で「ハングする」という形で観測しましたが、エミュレーション由来の可能性を排除するため
**arm64 でネイティブ実行**して確認したところ SIGSEGV で再現しました。

よって **musl (Alpine) + arm64 (Graviton) を維持**しており、
`serverless.yml` と CI ランナーのアーキテクチャは**変更していません**。
アーキ切替に伴うデプロイ上の注意 (フルの `sls deploy` が必要 等) も今回は該当しません。

## 検証

- Alpine(musl)/arm64 で静的バイナリをビルドし、**実際の実行環境イメージ
  `public.ecr.aws/lambda/provided:al2023` 上で** Lambda Runtime API のモックに対して疎通確認
- ✅ `Content-Length` 形式 / `chunked` 形式の双方、マルチバイト UTF-8
- ✅ 静的リンクであること (`! ldd bootstrap`)
- ✅ **生成物が実際に起動すること**のアサートを Dockerfile に追加

最後の項目は今回の glibc 静的リンクの問題が**従来の `! ldd` によるチェックでは検知できなかった**
（リンクは成功し ldd 的にも静的だが起動しない）ことを踏まえた追加です。

## #28 の TODO 対応状況

- [x] Dockerfile から libcurl の推移的依存を排除し縮小 → **最小 curl のソースビルドで達成 (案5)**
- [x] 生成バイナリが静的であることを検証
- [x] 不成立だった場合の判断を記録する
- [x] README / Dockerfile コメントの更新
- [ ] ~~`Lambda.scala` の sttp(libcurl) をソケット実装へ置き換え~~ → **趣旨から外れるため見送り**
- [ ] ~~`project.scala` から toolkit を外す~~ → **同上 (sttp を使い続けるため)**
- [ ] ~~`virtuslab/scala-cli` ベース / x86_64 / CI ランナー変更~~ → **glibc 静的リンク不成立のため見送り**

🤖 Generated with [Claude Code](https://claude.com/claude-code)