### PR TITLE
build: 公式イメージ + x86_64 で glibc 完全静的リンクする (#28)

### DIFF
--- a/.github/workflows/serverless-dev.yml
+++ b/.github/workflows/serverless-dev.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   deploy:
     name: deploy
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
     steps:
       - name: add-mask
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,32 @@
-# ビルド専用イメージ: Scala Native の `bootstrap` を Alpine (musl) 上で完全静的リンクする。
+# ビルド専用イメージ: Scala Native の `bootstrap` を scala-cli 公式イメージ
+# (Debian/glibc) 上で完全静的リンクする (#28)。
 # 生成物はコンテナイメージではなく、抽出して Lambda の zip
 # (provided.al2023 カスタムランタイム) としてデプロイする。
-FROM --platform=linux/arm64 alpine:3.21 AS build-image
+#
+# 公式イメージは amd64 単一アーキのため x86_64 が前提となる (#21 の arm64 化を巻き戻す)。
+# 以前は Alpine (musl) 上でビルドしていたが、musl 版は JDK / gcompat / musl 用 JVM の
+# 用意と *-static パッケージの取り回しが必要だった。公式イメージにはツールチェーンと
+# scala-cli が同梱されており、Debian の -dev パッケージは静的アーカイブ(.a)も含むため
+# それらがまるごと不要になる。タグは再現性のためバージョン固定する。
+FROM --platform=linux/amd64 virtuslab/scala-cli:1.16.0 AS build-image
 
-# clang/lld/llvm: Scala Native のコンパイル/リンク
-# gcompat: scala-cli の glibc 製ランチャを musl 上で動かす
-# openjdk17: システム JVM (musl ネイティブ)
-# libidn2/libunistring: libcurl ではなく sttp-model が @link("idn2") で要求する
-RUN apk add --no-cache \
-      curl \
-      build-base clang lld llvm \
-      gcompat libstdc++ libstdc++-dev libgcc \
-      openjdk17 \
-      libidn2-static libidn2-dev \
-      libunistring-static libunistring-dev
-
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
-ENV PATH="${JAVA_HOME}/bin:${PATH}"
-
-RUN curl -fsSL https://github.com/VirtusLab/scala-cli/releases/latest/download/scala-cli-aarch64-pc-linux.gz \
-      | gunzip > /usr/local/bin/scala-cli \
-    && chmod +x /usr/local/bin/scala-cli
+# イメージには Debian(stable-slim) + build-essential + clang + scala-cli が入っている。
+# 追加で要るのは以下だけ。
+#   curl / ca-certificates: libcurl のソース取得
+#   file                  : 静的リンクの検証用 (下部参照)
+#   libidn2 / libunistring: libcurl ではなく sttp-model が @link("idn2") で要求する
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+         curl ca-certificates file libidn2-dev libunistring-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # 最小構成の libcurl を静的ビルドする (#28)。
-# Alpine の curl-static は OpenSSL/nghttp2/brotli/zstd/psl/c-ares 込みのため、静的リンク
-# するとそれら全ての静的アーカイブが要る (うち brotli/libpsl は Alpine の *-static が
-# GCC LTO アーカイブでクロス ld が解決できず、ソースからの非LTOビルドが必要だった)。
-# 通信相手は Lambda Runtime API だけで TLS も名前解決も HTTP/2 も圧縮も不要なので、
-# それらを無効にして自前ビルドすれば依存ごと消える。
+# ディストリの curl は OpenSSL/nghttp2/brotli/zstd/psl/c-ares 込みのため、静的リンク
+# するとそれら全ての静的アーカイブが芋づる式に要る。通信相手は Lambda Runtime API
+# だけで TLS も名前解決も HTTP/2 も圧縮も不要なので、それらを無効にして自前ビルド
+# すれば依存ごと消える。
+# --prefix=/usr/local に入れると clang/ld の既定探索パスに載るため、ヘッダ側の
+# -I 指定は不要 (ライブラリ側は下の -L/usr/local/lib で明示する)。
 ARG CURL_VERSION=8.11.1
 RUN curl -fsSL "https://curl.se/download/curl-${CURL_VERSION}.tar.gz" | tar xz -C /tmp \
     && cd "/tmp/curl-${CURL_VERSION}" \
@@ -46,28 +45,39 @@ COPY ./ ./
 
 RUN scala-cli clean .
 RUN scala-cli config power true
-#  --jvm system   : musl ネイティブの openjdk17 を使う (glibc JVM の自動DLを回避)
 #  --server=false : Bloop ビルドサーバを使わずインプロセスでビルド
 #  --native-linking: リンクオプションは Linux/リンカー依存のため project.scala ではなく
 #    ここで指定し、macOS/Windows でのローカル開発を壊さないようにする。
 #    Scala Native は @link 由来の -l を独自順で並べるため、解決順序に依存しないよう
 #    ライブラリ群は 1 つの -Wl, 引数にまとめて原子的に渡す。
-RUN scala-cli --power package --native --jvm system --server=false \
+#
+#  --wrap=dlopen / --defsym=__wrap_dlopen=getenv について:
+#    Scala Native ランタイムは起動時のスタック境界検出で
+#    dlopen("libpthread.so.0") → dlsym → dlclose と進み、**アンロード済み**の関数
+#    ポインタを呼ぶ (nativeThreadTLS.c の get_pthread_getattr_np)。glibc 完全静的
+#    リンクではこれが解放済みコードへの分岐になり、起動直後に SIGSEGV する
+#    (println だけの最小プログラムでも再現する Scala Native 0.5.12 側の不具合)。
+#    そこで dlopen の呼び出しを libc の getenv へ差し替えて常に NULL を返させ、
+#    近似スタック境界へのフォールバックに落とす。dlopen は失敗時 NULL、getenv も
+#    未定義の名前に対し NULL を返すため戻り値の形が一致し、dlopen の第 2 引数は
+#    レジスタ渡しで無視される。
+#    このフォールバック経路は、musl の静的 dlopen が常に失敗する Alpine 版で従来から
+#    使われていたものと同一であり、実行時の挙動に新規性はない。
+RUN scala-cli --power package --native --server=false \
       --native-linking "-static" \
+      --native-linking "-Wl,--wrap=dlopen" \
+      --native-linking "-Wl,--defsym=__wrap_dlopen=getenv" \
       --native-linking "-L/usr/local/lib" \
       --native-linking "-Wl,--start-group,-lcurl,-lidn2,-lunistring,--end-group" \
       -o bootstrap .
 RUN chmod +x bootstrap
-# 静的リンクの検証。musl では静的バイナリへの ldd が非ゼロ終了するので ! で反転する。
-RUN ! ldd bootstrap
+# 静的リンクの検証。musl の ldd は静的バイナリに対し非ゼロ終了するのでそれを利用できたが、
+# glibc の ldd は挙動が異なるため file で判定する。
+RUN file bootstrap | grep -q "statically linked"
 # 起動できることの検証。_HANDLER 未設定なので NoSuchElementException で即終了するのが正常。
-# リンクが通り ldd 上も静的なのに起動しない構成 (下記 glibc + -static) を検知するため。
+# リンクが通り静的でもある (= 上の 2 つのチェックは通る) のに起動しない、という上記
+# dlopen 由来の状態を検知するため。
 RUN ./bootstrap 2>&1 | grep -q "NoSuchElementException: _HANDLER"
-
-# #28 の本命だった「libcurl 排除 + 公式イメージ virtuslab/scala-cli (glibc) で x86_64」は
-# 不採用。HTTP を自前実装することになり趣旨から外れる上、glibc + -static の Scala Native
-# バイナリはリンクは通るが起動直後に SIGSEGV する (println("hello") だけでも再現。
-# 動的リンクなら正常、musl なら静的でも正常)。よって musl + arm64 を維持している。
 
 # ============================================================================
 # 以下は Docker(コンテナイメージ)版の Lambda デプロイ用 Dockerfile。

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,28 +78,3 @@ RUN file bootstrap | grep -q "statically linked"
 # リンクが通り静的でもある (= 上の 2 つのチェックは通る) のに起動しない、という上記
 # dlopen 由来の状態を検知するため。
 RUN ./bootstrap 2>&1 | grep -q "NoSuchElementException: _HANDLER"
-
-# ============================================================================
-# 以下は Docker(コンテナイメージ)版の Lambda デプロイ用 Dockerfile。
-# zip(provided.al2023 カスタムランタイム)版へ移行したため無効化している。
-# サンプル実装として両方式を残すためコメントで保持。
-# ============================================================================
-#
-# FROM virtuslab/scala-cli:latest as build-image
-#
-# RUN apt-get update && apt-get install -y libcurl4-openssl-dev && rm -rf /var/lib/apt/lists/*
-#
-# WORKDIR /work
-# COPY ./ ./
-#
-# RUN scala-cli clean .
-# RUN scala-cli config power true
-# RUN scala-cli --power package --native -o bootstrap .
-# RUN chmod +x bootstrap
-#
-# # コンテナイメージ版ではここで Lambda 用ベースイメージに bootstrap を載せていた
-# FROM public.ecr.aws/lambda/provided:latest
-#
-# COPY --from=build-image /work/bootstrap /var/runtime/
-#
-# CMD ["dummyHandler"]

--- a/README.md
+++ b/README.md
@@ -32,11 +32,3 @@ $ npm install
 # deploy (bootstrap の生成 → zip化 → アップロードまで自動)
 $ sls deploy --stage <stage_name>
 ```
-
-## Docker（コンテナイメージ）版について
-
-このリポジトリはサンプル実装のため、以前の Docker イメージ
-（ECR コンテナイメージ）版のデプロイ設定も各ファイルにコメントで残してある。
-
-  - [serverless.yml](serverless.yml): `ecr.images` / `image.command` などをコメント保持
-  - [Dockerfile](Dockerfile): コンテナイメージ用のビルドステージをコメント保持

--- a/README.md
+++ b/README.md
@@ -11,11 +11,15 @@ Scalaらしいコードを書けたかというと微妙な気がするがまあ
 ## デプロイ
 
 `bootstrap` (Scala Nativeバイナリ) をビルドして zip でアップロードする。
-ビルドは Alpine (musl) コンテナ内で **静的リンク (static build)** して行う ([Dockerfile](Dockerfile))。
+ビルドは scala-cli 公式イメージ (`virtuslab/scala-cli`, Debian/glibc) 内で
+**静的リンク (static build)** して行う ([Dockerfile](Dockerfile))。
 完全静的リンクにより Lambda 実行環境 (provided.al2023) の glibc/libcurl の
 バージョンに依存しない自己完結バイナリになるため、ビルド環境とランタイム環境の
 ライブラリ整合を取る必要がなくなる (#22)。
 (以前は glibc/libcurl を一致させるため Amazon Linux 2023 上でビルドしていた)。
+
+公式イメージが amd64 単一アーキのため、Lambda のアーキテクチャは x86_64 (#28)。
+Apple Silicon 等でローカルビルドする場合は QEMU エミュレーションになる点に注意。
 
 `serverless-plugin-scripts` により、`sls deploy` / `sls package` の
 パッケージング直前 (`before:package:createDeploymentArtifacts`) に

--- a/project.scala
+++ b/project.scala
@@ -1,12 +1,8 @@
-// for GraalVM
-// //> using packaging.graalvmArgs --static
-// //> using packaging.graalvmArgs --no-fallback
-// for Scala Native
 //> using platform native
 //> using toolkit default
 //> using dep "com.lihaoyi::upickle:4.4.2"
 
-// 静的(musl)リンクのオプションは project.scala には置かない (#22)。
+// 静的リンクのオプションは project.scala には置かない (#22)。
 // -static や -Wl,--start-group 等は Linux/リンカー依存で、macOS/Windows での
-// ローカル開発(scala-cli run/test)を壊すため、Alpine ビルド時の scala-cli
+// ローカル開発(scala-cli run/test)を壊すため、コンテナビルド時の scala-cli
 // コマンドに --native-linking フラグとして渡す (Dockerfile 参照)。

--- a/serverless.yml
+++ b/serverless.yml
@@ -9,7 +9,14 @@ custom:
     hooks:
       # パッケージング(zip化)直前に、Lambda互換のネイティブバイナリ bootstrap を
       # Docker内でビルドして取り出す。
+      # set -e / rm -f は、前回ビルドの bootstrap が残っている状態で docker が失敗した
+      # 場合に、それを掴んだままデプロイしてしまうのを防ぐため。プラグインは
+      # execSync(= sh -c)で実行するので、既定では途中のコマンドが失敗しても後続に進み、
+      # 最後の chmod が成功する限りフックは成功扱いになる。アーキテクチャを跨いで
+      # 古いバイナリが残っていると Runtime.InvalidEntrypoint になる。
       "before:package:createDeploymentArtifacts": |
+        set -e
+        rm -f bootstrap
         docker build --platform linux/amd64 -t lambda-scala-sls-build .
         id=$(docker create --platform linux/amd64 lambda-scala-sls-build)
         docker cp "$id":/work/bootstrap ./bootstrap

--- a/serverless.yml
+++ b/serverless.yml
@@ -24,15 +24,6 @@ provider:
   timeout: 20
   region: ap-northeast-1
   stage: ${opt:stage, self:custom.defaultStage}
-  # --- Docker(コンテナイメージ)版のデプロイ設定。zip版へ移行したため無効化 ---
-  # runtime: provided
-  # ecr:
-  #   images:
-  #     appImage:
-  #       path: ./
-  #       platform: linux/amd64
-  # environment:
-  #   ${file(./env.yml)}
 
 # zip には bootstrap のみ含める
 package:
@@ -44,22 +35,12 @@ functions:
   hello:
     # handler の値が環境変数 _HANDLER に渡り、Lambda.scala のディスパッチに使われる
     handler: hello
-    # --- Docker版: コンテナイメージ + command でハンドラ指定 ---
-    # image:
-    #   name: appImage
-    #   command:
-    #     - hello
     events:
       - http:
           path: test
           method: get
   world:
     handler: world
-    # --- Docker版: コンテナイメージ + command でハンドラ指定 ---
-    # image:
-    #   name: appImage
-    #   command:
-    #     - world
     events:
       - http:
           path: test

--- a/serverless.yml
+++ b/serverless.yml
@@ -10,8 +10,8 @@ custom:
       # パッケージング(zip化)直前に、Lambda互換のネイティブバイナリ bootstrap を
       # Docker内でビルドして取り出す。
       "before:package:createDeploymentArtifacts": |
-        docker build --platform linux/arm64 -t lambda-scala-sls-build .
-        id=$(docker create --platform linux/arm64 lambda-scala-sls-build)
+        docker build --platform linux/amd64 -t lambda-scala-sls-build .
+        id=$(docker create --platform linux/amd64 lambda-scala-sls-build)
         docker cp "$id":/work/bootstrap ./bootstrap
         docker rm "$id"
         chmod +x bootstrap
@@ -19,7 +19,8 @@ custom:
 provider:
   name: aws
   runtime: provided.al2023
-  architecture: arm64
+  # ビルドに使う scala-cli 公式イメージが amd64 単一アーキのため x86_64 (#28)
+  architecture: x86_64
   timeout: 20
   region: ap-northeast-1
   stage: ${opt:stage, self:custom.defaultStage}
@@ -29,7 +30,7 @@ provider:
   #   images:
   #     appImage:
   #       path: ./
-  #       platform: linux/arm64
+  #       platform: linux/amd64
   # environment:
   #   ${file(./env.yml)}
 


### PR DESCRIPTION
Refs #28 / **#29 へのスタックPR** (base は `feat/minimize-dockerfile-issue-28`)

#29 で「技術的に成立しない」として見送った **(b-2)（x86_64 + 公式イメージ + glibc 完全静的リンク）を、HTTP クライアントの自前実装なしで成立させます。** #29 の最小 libcurl ソースビルドはそのまま活かし、ビルド基盤だけを Alpine(musl)/arm64 → `virtuslab/scala-cli`(Debian/glibc)/x86_64 へ移します。

**Scala のコードは #29 同様いっさい変更していません。** さらに C ファイルの追加もありません（後述の回避策はリンカオプション 2 つのみ）。

## #29 で見送った SIGSEGV の真因

#29 では「Scala Native ランタイムと glibc 静的リンクの相性問題」として原因未特定のまま見送っていましたが、x86_64 ネイティブ環境で再現し gdb で追ったところ、**Scala Native 0.5.12 の use-after-dlclose バグ**であることが判明しました。glibc 静的リンクの本質的な限界ではありません。

```
#0  0x00007ffbc869de50 in ?? ()                          <- アンロード済み領域
#1  0x00000000004b1e0f in detectStackBounds ()
#2  0x00000000004b1d62 in scalanative_setupCurrentThreadInfo ()
#3  ... in scala.scalanative.runtime.package$.init ()
#4  0x0000000000401c1c in main ()
```

起動時のスタック境界検出 `get_pthread_getattr_np()`（`nativeThreadTLS.c`）が次の動きをします。

1. `dlsym(RTLD_DEFAULT, ...)` の fast-path は `_GNU_SOURCE` 未定義のためコンパイルされていない
2. フォールバックの `dlopen("libpthread.so.0", RTLD_NOW)` に入る
3. `dlsym()` でロード先の関数ポインタを取得
4. **`dlclose()` でアンロードしてから、そのポインタを呼ぶ** → 解放済みコードへの分岐 → SIGSEGV

動的リンクなら libpthread が既にプロセスに載っているため顕在化せず、musl 静的なら musl の静的 `dlopen` が常に失敗して近似スタック境界のフォールバックに落ちるため無事でした。**つまり現行の Alpine 版も、実は最初からこのフォールバック経路で動いています。** glibc 静的リンクだけが「dlopen は成功するがアンロード後に呼ぶ」という最悪の組み合わせを踏んでいました。

なお `dlopen`/`dlclose` を除いた最小 C プログラムで単離再現でき、upstream の main ブランチも同一コードのため **0.5.12 時点で未修正**です。

## 回避策：リンカオプション 2 つ

```
--native-linking "-Wl,--wrap=dlopen"
--native-linking "-Wl,--defsym=__wrap_dlopen=getenv"
```

バイナリ中で唯一の `dlopen` 呼び出しを `__wrap_dlopen` へ付け替え、それを libc 既存の **`getenv`** にエイリアスします。`dlopen("libpthread.so.0", RTLD_NOW)` は `getenv("libpthread.so.0")` になり、そんな環境変数は無いので**常に NULL**（= dlopen 失敗と同じ形。第 2 引数はレジスタ渡しのため無視される）。結果、**musl 版が従来使っていたのと同一のフォールバック経路**に落ちます。実行時の挙動に新規性はありません。

当初 12 行の C シムで dlsym を差し替える案も検証しましたが、**（ライブラリではない）C コードへの依存はこのリポジトリの趣旨に反する**ため、リンカオプションのみで完結するこちらを採りました。

`--native-multithreading=false`（公式フラグのみで済む可能性があった案）も試しましたが、同じ初期化経路を通るため回避できませんでした。

## なにが減ったか

公式イメージには Debian(stable-slim) + build-essential + clang + scala-cli が同梱されており、Debian の `-dev` パッケージは静的アーカイブ(.a)も含むため、musl 版で必要だった以下がまるごと不要になります。

- **JDK / `JAVA_HOME` 設定 / `--jvm system`**（musl ネイティブ JVM を用意する必要がなくなる）
- **gcompat**（glibc 製 scala-cli ランチャを musl 上で動かすためのもの）
- **scala-cli launcher の curl ダウンロード**（イメージに入っている）
- **`libidn2-static` / `libunistring-static`**（Debian は `-dev` に .a 同梱、`*-static` 相当が不要）
- `lld` / `llvm` / `libstdc++-dev` 等の明示インストール

あわせて、役割を終えた**過去実装のコメントアウトを削除**しました（2 コミット目）。zip 版に一本化されて久しい Docker(コンテナイメージ)版のビルドステージは、本 PR でビルド基盤が公式イメージへ移ったことで稼働中の記述とほぼ同内容になったためです。`serverless.yml` の `ecr.images` / `image.command`、それらを説明していた README の節、および `project.scala` の GraalVM 用ディレクティブ（対応する Dockerfile 側の `--native-image` 行は #29 で削除済みで孤立していた）も同時に削除しています。

| | 有効行 | 全行 |
|---|---:|---:|
| master | 50 | 166 |
| #29 | 37 | 95 |
| 本PR | **31** | **80** |

行数の削減幅自体は控えめですが、**「静的リンクを通すための細工」が Dockerfile から実質消えた**のが本質です。#29 で LTO アーカイブ回避が消え、本 PR で musl 環境を成立させるための一群（JVM・gcompat・static パッケージ）が消えました。残るのは上記のリンカオプション 2 行と、その理由のコメントだけです。

## 検証

x86_64 ネイティブ（Ubuntu 24.04 / glibc 2.39 / clang 18 / scala-cli 1.16.0）で、Dockerfile と同一のフラグでビルドして実施。

- ✅ **SIGSEGV の再現**（フラグなしの glibc 静的ビルド）— QEMU 抜きのネイティブ実行で #29 の報告を確認
- ✅ 本リポジトリの実コード（sttp + 最小 libcurl 8.11.1 + idn2/unistring）で静的リンク成功
- ✅ Dockerfile のアサート 2 つ（`file` が `statically linked` / `NoSuchElementException: _HANDLER` で起動）
- ✅ モック Lambda Runtime API に対し **hello・world 両ハンドラ**、`Content-Length` 形式 / `chunked` 形式の双方、マルチバイト UTF-8
- ✅ 例外経路（不正 body → catch → `/error` POST）= libunwind のスタック巻き戻しが静的リンクでも機能すること
- ✅ **strace による全ファイルアクセス監査**: プロセスの全生存期間で open するのは `/proc/self/maps` の 1 件のみ。共有ライブラリ・dlopen・NSS・/etc へのアクセスはゼロ
- ✅ **空 chroot**（共有ライブラリ皆無、`/proc` のみマウント）で world ハンドラが完走 — 実行環境の glibc バージョンに一切依存しないことの実証

最後の 2 つは、#28 が懸念していた「glibc 完全静的リンクの NSS 問題」が**実際に発生しないこと**の確認を兼ねています。

### 未実施の検証

作業環境のネットワークポリシーによりコンテナレジストリの blob 取得が全面的に拒否されたため、**`docker build` の一気通貫と実 Lambda へのデプロイは行えていません。** 上記は同等構成（Debian 系 glibc + clang + scala-cli 1.16.0）のホスト上で Dockerfile と同一手順・同一フラグを再現したものです。#29 が行っていた `public.ecr.aws/lambda/provided:al2023` 上での実行確認も同じ理由で代替（空 chroot）としています。CI での確認をお願いします。

## デプロイ時の注意（#28 の記載どおり）

- **切替は必ずフルの `sls deploy` で。** `sls deploy function -f <name>` は CloudFormation を経由せず zip だけ差し替えるため、アーキ設定が arm64 のまま x86_64 バイナリが載り `Runtime.InvalidEntrypoint` になります
- CI ランナーの `ubuntu-24.04` 化を同一 PR に含めています（`ubuntu-24.04-arm` のまま `--platform linux/amd64` を指定すると QEMU 経由になり極端に遅い / binfmt 未設定で失敗する）
- `Architectures` は CloudFormation で置換を伴わない更新可能プロパティのため、関数 ARN・API Gateway の紐付け・エンドポイント URL は維持されます

## 残る留意点

- 根本原因は Scala Native 側のバグ（use-after-dlclose）なので、**upstream への issue 報告を推奨**します。修正がリリースされればこのリンカオプション 2 行も削除できます。必要であれば報告用の文面を用意します
- Lambda 実行コストが約 20% 上がります（Graviton → x86_64）。#21 の判断の巻き戻しです
- Apple Silicon でのローカルビルドは QEMU エミュレーションになり遅くなります（README に注記済み）
- 公式イメージは約 1.5GB のため初回 pull が重くなります