### PR TITLE
docs: コメントを日本語技術文書として読みやすく全体的に見直す

### DIFF
--- a/.github/workflows/serverless-dev.yml
+++ b/.github/workflows/serverless-dev.yml
@@ -24,8 +24,8 @@ jobs:
       - name: checkout
         uses: actions/checkout@v1
 
-      # zip版デプロイに必要な serverless-plugin-scripts を導入
-      # (パッケージング直前に Docker で bootstrap をビルドして取り出す)
+      # パッケージング直前に Docker で bootstrap をビルドして取り出すための
+      # serverless-plugin-scripts を導入する (serverless.yml のフック参照)
       - name: install plugins
         run: npm install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,32 @@
-# ビルド専用イメージ: Scala Native の `bootstrap` を scala-cli 公式イメージ
+# ビルド専用イメージ: Scala Native 製バイナリ bootstrap を scala-cli 公式イメージ
 # (Debian/glibc) 上で完全静的リンクする (#28)。
-# 生成物はコンテナイメージではなく、抽出して Lambda の zip
-# (provided.al2023 カスタムランタイム) としてデプロイする。
+# このイメージ自体をデプロイするのではなく、生成した bootstrap を抽出して
+# Lambda の zip (provided.al2023 カスタムランタイム) としてデプロイする。
 #
-# 公式イメージは amd64 単一アーキのため x86_64 が前提となる (#21 の arm64 化を巻き戻す)。
-# 以前は Alpine (musl) 上でビルドしていたが、musl 版は JDK / gcompat / musl 用 JVM の
-# 用意と *-static パッケージの取り回しが必要だった。公式イメージにはツールチェーンと
-# scala-cli が同梱されており、Debian の -dev パッケージは静的アーカイブ(.a)も含むため
-# それらがまるごと不要になる。タグは再現性のためバージョン固定する。
+# 公式イメージは amd64 のみの提供のため、x86_64 が前提となる (#21 の arm64 化を巻き戻す)。
+# 以前は Alpine (musl) 上でビルドしていたが、その構成では JDK / gcompat / musl 用 JVM
+# の用意と *-static パッケージの取り回しが必要だった。公式イメージにはツールチェーンと
+# scala-cli が同梱されており、Debian の -dev パッケージは静的アーカイブ (.a) も含むため、
+# それらの手当てがまるごと不要になる。タグは再現性のためバージョン固定する。
 FROM --platform=linux/amd64 virtuslab/scala-cli:1.16.0 AS build-image
 
-# イメージには Debian(stable-slim) + build-essential + clang + scala-cli が入っている。
-# 追加で要るのは以下だけ。
-#   curl / ca-certificates: libcurl のソース取得
-#   file                  : 静的リンクの検証用 (下部参照)
-#   libidn2 / libunistring: libcurl ではなく sttp-model が @link("idn2") で要求する
+# イメージには Debian (stable-slim) + build-essential + clang + scala-cli が入っている。
+# 追加で必要なのは以下だけ。
+#   curl / ca-certificates : libcurl のソース取得用
+#   file                   : 静的リンクの検証用 (最下部参照)
+#   libidn2 / libunistring : libcurl ではなく sttp-model が @link("idn2") で要求する
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
          curl ca-certificates file libidn2-dev libunistring-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # 最小構成の libcurl を静的ビルドする (#28)。
-# ディストリの curl は OpenSSL/nghttp2/brotli/zstd/psl/c-ares 込みのため、静的リンク
-# するとそれら全ての静的アーカイブが芋づる式に要る。通信相手は Lambda Runtime API
-# だけで TLS も名前解決も HTTP/2 も圧縮も不要なので、それらを無効にして自前ビルド
-# すれば依存ごと消える。
-# --prefix=/usr/local に入れると clang/ld の既定探索パスに載るため、ヘッダ側の
-# -I 指定は不要 (ライブラリ側は下の -L/usr/local/lib で明示する)。
+# ディストリビューションの curl は OpenSSL/nghttp2/brotli/zstd/psl/c-ares 込みのため、
+# 静的リンクするとそれら全ての静的アーカイブが芋づる式に必要になる。このランタイムの
+# 通信相手は Lambda Runtime API だけで、TLS も名前解決も HTTP/2 も圧縮も使わない。
+# そこでそれらを無効にして自前ビルドし、依存ごと消す。
+# --prefix=/usr/local に入れると clang/ld の既定の探索パスに載るため、ヘッダ側の
+# -I 指定は不要になる (ライブラリ側は下の -L/usr/local/lib で明示する)。
 ARG CURL_VERSION=8.11.1
 RUN curl -fsSL "https://curl.se/download/curl-${CURL_VERSION}.tar.gz" | tar xz -C /tmp \
     && cd "/tmp/curl-${CURL_VERSION}" \
@@ -45,24 +45,24 @@ COPY ./ ./
 
 RUN scala-cli clean .
 RUN scala-cli config power true
-#  --server=false : Bloop ビルドサーバを使わずインプロセスでビルド
-#  --native-linking: リンクオプションは Linux/リンカー依存のため project.scala ではなく
-#    ここで指定し、macOS/Windows でのローカル開発を壊さないようにする。
-#    Scala Native は @link 由来の -l を独自順で並べるため、解決順序に依存しないよう
-#    ライブラリ群は 1 つの -Wl, 引数にまとめて原子的に渡す。
+#  --server=false : Bloop ビルドサーバを使わず、インプロセスでビルドする。
+#  --native-linking : リンクオプションは Linux のリンカーに依存するため、project.scala
+#    ではなくここで指定し、macOS/Windows でのローカル開発を壊さないようにする。
+#    Scala Native は @link 由来の -l を独自の順序で並べるため、解決順序に依存しない
+#    よう、ライブラリ群は 1 つの -Wl 引数にまとめて原子的に渡す。
 #
 #  --wrap=dlopen / --defsym=__wrap_dlopen=getenv について:
-#    Scala Native ランタイムは起動時のスタック境界検出で
-#    dlopen("libpthread.so.0") → dlsym → dlclose と進み、**アンロード済み**の関数
-#    ポインタを呼ぶ (nativeThreadTLS.c の get_pthread_getattr_np)。glibc 完全静的
-#    リンクではこれが解放済みコードへの分岐になり、起動直後に SIGSEGV する
-#    (println だけの最小プログラムでも再現する Scala Native 0.5.12 側の不具合)。
-#    そこで dlopen の呼び出しを libc の getenv へ差し替えて常に NULL を返させ、
-#    近似スタック境界へのフォールバックに落とす。dlopen は失敗時 NULL、getenv も
-#    未定義の名前に対し NULL を返すため戻り値の形が一致し、dlopen の第 2 引数は
-#    レジスタ渡しで無視される。
-#    このフォールバック経路は、musl の静的 dlopen が常に失敗する Alpine 版で従来から
-#    使われていたものと同一であり、実行時の挙動に新規性はない。
+#    Scala Native ランタイムは起動時のスタック境界検出で dlopen("libpthread.so.0")、
+#    dlsym、dlclose と進んだあと、アンロード済みの関数ポインタを呼んでしまう
+#    (nativeThreadTLS.c の get_pthread_getattr_np)。glibc の完全静的リンクでは
+#    これが解放済みコードへの分岐になり、起動直後に SIGSEGV する (println だけの
+#    最小プログラムでも再現する、Scala Native 0.5.12 側の不具合)。
+#    そこで dlopen の呼び出しを libc の getenv に差し替えて常に NULL を返させ、
+#    近似スタック境界へのフォールバックに落とす。この差し替えが成立するのは、
+#    dlopen が失敗時に NULL を返し、getenv も未定義の名前に対して NULL を返すため
+#    戻り値の形が一致し、dlopen の第 2 引数はレジスタ渡しで単に無視されるからである。
+#    このフォールバック経路は、静的リンクでは dlopen が常に失敗する musl (旧 Alpine 版)
+#    で従来から通っていた経路と同じであり、実行時の挙動として新しいものではない。
 RUN scala-cli --power package --native --server=false \
       --native-linking "-static" \
       --native-linking "-Wl,--wrap=dlopen" \
@@ -71,10 +71,10 @@ RUN scala-cli --power package --native --server=false \
       --native-linking "-Wl,--start-group,-lcurl,-lidn2,-lunistring,--end-group" \
       -o bootstrap .
 RUN chmod +x bootstrap
-# 静的リンクの検証。musl の ldd は静的バイナリに対し非ゼロ終了するのでそれを利用できたが、
-# glibc の ldd は挙動が異なるため file で判定する。
+# 静的リンクの検証。musl の ldd は静的バイナリに対して非ゼロ終了するのでそれで判定
+# できたが、glibc の ldd は挙動が異なるため file の出力で判定する。
 RUN file bootstrap | grep -q "statically linked"
-# 起動できることの検証。_HANDLER 未設定なので NoSuchElementException で即終了するのが正常。
-# リンクが通り静的でもある (= 上の 2 つのチェックは通る) のに起動しない、という上記
-# dlopen 由来の状態を検知するため。
+# 起動できることの検証。リンクが通り静的にもなっている (= 上の 2 つのチェックは通る)
+# のに起動はしない、という前述の dlopen 由来の壊れ方を検知するため。
+# _HANDLER 未設定なので、NoSuchElementException で即終了するのが正常。
 RUN ./bootstrap 2>&1 | grep -q "NoSuchElementException: _HANDLER"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,23 @@
-# ビルド専用イメージ: Scala Native 製バイナリ bootstrap を scala-cli 公式イメージ
-# (Debian/glibc) 上で完全静的リンクする (#28)。
-# このイメージ自体をデプロイするのではなく、生成した bootstrap を抽出して
-# Lambda の zip (provided.al2023 カスタムランタイム) としてデプロイする。
-#
-# 公式イメージは amd64 のみの提供のため、x86_64 が前提となる (#21 の arm64 化を巻き戻す)。
-# 以前は Alpine (musl) 上でビルドしていたが、その構成では JDK / gcompat / musl 用 JVM
-# の用意と *-static パッケージの取り回しが必要だった。公式イメージにはツールチェーンと
-# scala-cli が同梱されており、Debian の -dev パッケージは静的アーカイブ (.a) も含むため、
-# それらの手当てがまるごと不要になる。タグは再現性のためバージョン固定する。
+# Lambda の zip (provided.al2023 カスタムランタイム) に入れる bootstrap を
+# 完全静的リンクでビルドする専用イメージ。デプロイするのは抽出したバイナリだけで、
+# このイメージ自体はデプロイしない。背景は README とその参照先 (#22, #28) を参照。
+# ベースの scala-cli 公式イメージは amd64 のみの提供のため、x86_64 が前提となる。
+# タグは再現性のためバージョン固定する。
 FROM --platform=linux/amd64 virtuslab/scala-cli:1.16.0 AS build-image
 
-# イメージには Debian (stable-slim) + build-essential + clang + scala-cli が入っている。
-# 追加で必要なのは以下だけ。
+# ベースイメージ (Debian + ツールチェーン + scala-cli) に足りないものだけ追加する。
 #   curl / ca-certificates : libcurl のソース取得用
 #   file                   : 静的リンクの検証用 (最下部参照)
-#   libidn2 / libunistring : libcurl ではなく sttp-model が @link("idn2") で要求する
+#   libidn2 / libunistring : sttp-model が @link("idn2") で要求する
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
          curl ca-certificates file libidn2-dev libunistring-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# 最小構成の libcurl を静的ビルドする (#28)。
-# ディストリビューションの curl は OpenSSL/nghttp2/brotli/zstd/psl/c-ares 込みのため、
-# 静的リンクするとそれら全ての静的アーカイブが芋づる式に必要になる。このランタイムの
-# 通信相手は Lambda Runtime API だけで、TLS も名前解決も HTTP/2 も圧縮も使わない。
-# そこでそれらを無効にして自前ビルドし、依存ごと消す。
-# --prefix=/usr/local に入れると clang/ld の既定の探索パスに載るため、ヘッダ側の
-# -I 指定は不要になる (ライブラリ側は下の -L/usr/local/lib で明示する)。
+# 最小構成の libcurl を静的ビルドする。通信相手は Lambda Runtime API だけなので
+# TLS も名前解決も HTTP/2 も圧縮も使わず、これらを切ればディストリビューション版の
+# 静的リンクで芋づる式に必要になる OpenSSL などの静的アーカイブごと不要になる。
+# /usr/local は clang/ld の既定の探索パスなので、ヘッダ側の -I 指定は不要になる。
 ARG CURL_VERSION=8.11.1
 RUN curl -fsSL "https://curl.se/download/curl-${CURL_VERSION}.tar.gz" | tar xz -C /tmp \
     && cd "/tmp/curl-${CURL_VERSION}" \
@@ -46,23 +37,14 @@ COPY ./ ./
 RUN scala-cli clean .
 RUN scala-cli config power true
 #  --server=false : Bloop ビルドサーバを使わず、インプロセスでビルドする。
-#  --native-linking : リンクオプションは Linux のリンカーに依存するため、project.scala
-#    ではなくここで指定し、macOS/Windows でのローカル開発を壊さないようにする。
-#    Scala Native は @link 由来の -l を独自の順序で並べるため、解決順序に依存しない
-#    よう、ライブラリ群は 1 つの -Wl 引数にまとめて原子的に渡す。
-#
-#  --wrap=dlopen / --defsym=__wrap_dlopen=getenv について:
-#    Scala Native ランタイムは起動時のスタック境界検出で dlopen("libpthread.so.0")、
-#    dlsym、dlclose と進んだあと、アンロード済みの関数ポインタを呼んでしまう
-#    (nativeThreadTLS.c の get_pthread_getattr_np)。glibc の完全静的リンクでは
-#    これが解放済みコードへの分岐になり、起動直後に SIGSEGV する (println だけの
-#    最小プログラムでも再現する、Scala Native 0.5.12 側の不具合)。
-#    そこで dlopen の呼び出しを libc の getenv に差し替えて常に NULL を返させ、
-#    近似スタック境界へのフォールバックに落とす。この差し替えが成立するのは、
-#    dlopen が失敗時に NULL を返し、getenv も未定義の名前に対して NULL を返すため
-#    戻り値の形が一致し、dlopen の第 2 引数はレジスタ渡しで単に無視されるからである。
-#    このフォールバック経路は、静的リンクでは dlopen が常に失敗する musl (旧 Alpine 版)
-#    で従来から通っていた経路と同じであり、実行時の挙動として新しいものではない。
+#  --native-linking : リンカー依存のオプションのため、project.scala ではなく
+#    ここで渡す (project.scala 冒頭のコメント参照)。ライブラリ群は Scala Native に
+#    よる並べ替えの影響を受けないよう、1 つの --start-group にまとめて渡す。
+#  --wrap=dlopen : glibc の完全静的リンクでは、Scala Native 0.5.12 が起動時の
+#    スタック境界検出で行う dlopen が解放済みコードの呼び出しになり、SIGSEGV する。
+#    そこで dlopen を getenv に差し替えて常に NULL を返させ (未知の名前への getenv は
+#    NULL を返し、呼び出しの形も互換)、近似スタック境界へのフォールバックに落とす。
+#    これは musl の静的リンク (dlopen が常に失敗する) で従来から通っていた経路と同じ。
 RUN scala-cli --power package --native --server=false \
       --native-linking "-static" \
       --native-linking "-Wl,--wrap=dlopen" \
@@ -71,10 +53,8 @@ RUN scala-cli --power package --native --server=false \
       --native-linking "-Wl,--start-group,-lcurl,-lidn2,-lunistring,--end-group" \
       -o bootstrap .
 RUN chmod +x bootstrap
-# 静的リンクの検証。musl の ldd は静的バイナリに対して非ゼロ終了するのでそれで判定
-# できたが、glibc の ldd は挙動が異なるため file の出力で判定する。
+# 静的リンクの検証 (glibc の ldd は musl と違い静的バイナリの判定に使えないため file で)
 RUN file bootstrap | grep -q "statically linked"
-# 起動できることの検証。リンクが通り静的にもなっている (= 上の 2 つのチェックは通る)
-# のに起動はしない、という前述の dlopen 由来の壊れ方を検知するため。
-# _HANDLER 未設定なので、NoSuchElementException で即終了するのが正常。
+# 起動できることの検証。前述の dlopen 問題はリンクが通っても起動時に落ちるため、
+# 実際に実行して確かめる。_HANDLER 未設定による NoSuchElementException 即終了が正常。
 RUN ./bootstrap 2>&1 | grep -q "NoSuchElementException: _HANDLER"

--- a/README.md
+++ b/README.md
@@ -10,25 +10,20 @@ Scalaらしいコードを書けたかというと微妙な気がするがまあ
 
 ## デプロイ
 
-`bootstrap` (Scala Nativeバイナリ) をビルドして zip でアップロードする。
-ビルドは scala-cli 公式イメージ (`virtuslab/scala-cli`, Debian/glibc) 内で
-**静的リンク (static build)** して行う ([Dockerfile](Dockerfile))。
-完全静的リンクにより Lambda 実行環境 (provided.al2023) の glibc/libcurl の
-バージョンに依存しない自己完結バイナリになるため、ビルド環境とランタイム環境の
-ライブラリ整合を取る必要がなくなる (#22)。
-(以前は glibc/libcurl を一致させるため Amazon Linux 2023 上でビルドしていた)。
+`bootstrap` (Scala Native バイナリ) をビルドし、zip でアップロードする。
+ビルドは scala-cli 公式イメージ (`virtuslab/scala-cli`, Debian/glibc) 内で行い、完全静的リンクする ([Dockerfile](Dockerfile))。
+静的リンクした自己完結バイナリは Lambda 実行環境 (provided.al2023) の glibc/libcurl のバージョンに依存しないため、ビルド環境とランタイム環境でライブラリの整合を取る必要がなくなる (#22)。
+(以前は glibc/libcurl を一致させるため Amazon Linux 2023 上で、その後 Alpine (musl) 上でビルドしていた。経緯は #22, #28 を参照。)
 
-公式イメージが amd64 単一アーキのため、Lambda のアーキテクチャは x86_64 (#28)。
-Apple Silicon 等でローカルビルドする場合は QEMU エミュレーションになる点に注意。
+公式イメージが amd64 のみの提供のため、Lambda のアーキテクチャは x86_64 にしている (#28)。
+Apple Silicon などでローカルビルドする場合は QEMU エミュレーションになる。
 
-`serverless-plugin-scripts` により、`sls deploy` / `sls package` の
-パッケージング直前 (`before:package:createDeploymentArtifacts`) に
-`bootstrap` が自動でビルド・取り出しされる (Docker が必要)。
+パッケージングは `serverless-plugin-scripts` のフックで自動化していて、`sls deploy` / `sls package` を実行すると zip 化の直前 (`before:package:createDeploymentArtifacts`) に Docker 内で `bootstrap` のビルドと取り出しが走る (Docker が必要)。
 
 ```shell
 # プラグインをインストール
 $ npm install
 
-# deploy (bootstrap の生成 → zip化 → アップロードまで自動)
+# デプロイ (bootstrap の生成から zip 化、アップロードまで自動)
 $ sls deploy --stage <stage_name>
 ```

--- a/project.scala
+++ b/project.scala
@@ -2,7 +2,8 @@
 //> using toolkit default
 //> using dep "com.lihaoyi::upickle:4.4.2"
 
-// 静的リンクのオプションは project.scala には置かない (#22)。
-// -static や -Wl,--start-group 等は Linux/リンカー依存で、macOS/Windows での
-// ローカル開発(scala-cli run/test)を壊すため、コンテナビルド時の scala-cli
-// コマンドに --native-linking フラグとして渡す (Dockerfile 参照)。
+// 静的リンクのオプションはこのファイルには置かない (#22)。
+// -static や -Wl,--start-group といったオプションは Linux のリンカーに依存していて、
+// ここに書くと macOS/Windows でのローカル開発 (scala-cli run/test) が壊れる。
+// そのため、コンテナビルド時の scala-cli コマンドに --native-linking フラグとして
+// 渡す形にしている (Dockerfile 参照)。

--- a/serverless.yml
+++ b/serverless.yml
@@ -7,13 +7,14 @@ custom:
   defaultStage: dev
   scripts:
     hooks:
-      # パッケージング(zip化)直前に、Lambda互換のネイティブバイナリ bootstrap を
-      # Docker内でビルドして取り出す。
-      # set -e / rm -f は、前回ビルドの bootstrap が残っている状態で docker が失敗した
-      # 場合に、それを掴んだままデプロイしてしまうのを防ぐため。プラグインは
-      # execSync(= sh -c)で実行するので、既定では途中のコマンドが失敗しても後続に進み、
-      # 最後の chmod が成功する限りフックは成功扱いになる。アーキテクチャを跨いで
-      # 古いバイナリが残っていると Runtime.InvalidEntrypoint になる。
+      # パッケージング (zip 化) の直前に、Lambda 互換のネイティブバイナリ bootstrap を
+      # Docker 内でビルドして取り出す。
+      # set -e と rm -f は、docker のビルドが失敗したときに前回の bootstrap を
+      # 掴んだままデプロイしてしまうのを防ぐためのもの。プラグインはこのフックを
+      # execSync (= sh -c) で実行するため、既定では途中のコマンドが失敗しても
+      # 後続へ進んでしまい、最後の chmod さえ成功すればフック全体が成功扱いになる。
+      # そうして残った古いバイナリがアーキテクチャの合わないものだと、デプロイ後に
+      # Runtime.InvalidEntrypoint で起動しなくなる。
       "before:package:createDeploymentArtifacts": |
         set -e
         rm -f bootstrap
@@ -26,7 +27,7 @@ custom:
 provider:
   name: aws
   runtime: provided.al2023
-  # ビルドに使う scala-cli 公式イメージが amd64 単一アーキのため x86_64 (#28)
+  # ビルドに使う scala-cli 公式イメージが amd64 のみの提供のため、x86_64 にする (#28)
   architecture: x86_64
   timeout: 20
   region: ap-northeast-1
@@ -40,7 +41,8 @@ package:
 
 functions:
   hello:
-    # handler の値が環境変数 _HANDLER に渡り、Lambda.scala のディスパッチに使われる
+    # handler の値は実行時に環境変数 _HANDLER として渡され、Lambda.scala の
+    # Handler がこの名前で呼び出す関数を選ぶ
     handler: hello
     events:
       - http:

--- a/src/runtime/Lambda.scala
+++ b/src/runtime/Lambda.scala
@@ -18,6 +18,9 @@ object Lambda {
       derives ReadWriter
   case class ErrorMessage(msg: String, error: String) derives ReadWriter
 
+  // 関数名が環境変数 _HANDLER (serverless.yml の handler の値) と一致したときだけ
+  // イベントループへ入る。一致しなければ何もせず自身を返すため、Handler を
+  // メソッドチェーンで並べて 1 つのバイナリに複数の関数を同居させられる。
   def Handler[A: Reader](name: String, callback: A => Response): Lambda.type = {
     if (name == sys.env("_HANDLER")) {
       handler(callback)
@@ -26,8 +29,9 @@ object Lambda {
     this
   }
   // Lambda カスタムランタイムのイベントループ。
-  // /next で次の呼び出しを取得 → callback 実行 → /response か /error を通知、を繰り返す。
-  // 末尾再帰(@tailrec)とし、長時間稼働(ウォーム)でもスタックが伸びないことを保証する。
+  // Runtime API の /next から次の呼び出しを取得し、callback を実行して、
+  // 結果を /response へ (例外時は /error へ) 通知する。これを無限に繰り返す。
+  // 末尾再帰 (@tailrec) なので、ウォームスタートで長時間稼働してもスタックは伸びない。
   @tailrec
   private def handler[A: Reader](callback: A => Response): Nothing = {
     val response = quickRequest


### PR DESCRIPTION
## 概要

コード中のコメントを、日本語の技術文書として読みやすくなるように全体的に見直しました。
挙動の変更はなく、コメントのみの変更です。

## 見直しの方針

- 矢印による処理の連鎖表記（「/next で取得 → callback 実行 → 通知」）を、動作の連なりを述べる文章に改めた
- 因果を主張する箇所には機構を添え、目的 → 機構 → 帰結の順に読めるよう段落を整理した（serverless.yml のビルドフック、Dockerfile の dlopen 差し替えの説明など）
- コメント内の Markdown 風強調（`**...**`）や表記ゆれ（括弧前後のスペース、「単一アーキ」など）を整えた

## 変更ファイル

- `src/runtime/Lambda.scala`: イベントループの説明を文章化。あわせて、serverless.yml から参照されている `Handler` のディスパッチ（`_HANDLER` との一致判定とメソッドチェーンで複数関数を同居させる仕組み）に説明コメントを追加
- `project.scala`: 静的リンクオプションをここに置かない理由を、規則 → 理由 → 代替の順に整理
- `serverless.yml`: ビルドフックの `set -e` / `rm -f` の理由を、防ぎたい事故 → プラグインの実行機構 → 放置した場合の帰結の順に再構成
- `Dockerfile`: 冒頭のイメージ説明、libcurl 最小ビルド、dlopen 差し替えの説明を文章として整理
- `.github/workflows/serverless-dev.yml`: プラグイン導入ステップのコメントを目的が先に来る形に変更

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwAZ3rTqVhcxzSCrofgR77)_